### PR TITLE
Increase vanilla ID limit to 32768

### DIFF
--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -59,8 +59,8 @@ public class Level {
 	public int w, h; // Width and height of the level
 	private long seed; // The used seed that was used to generate the world
 	
-	public byte[] tiles; // An array of all the tiles in the world.
-	public byte[] data; // An array of the data of the tiles in the world.
+	public short[] tiles; // An array of all the tiles in the world.
+	public short[] data; // An array of the data of the tiles in the world.
 	
 	public final int depth; // Depth level of the level
 	public int monsterDensity = 16; // Affects the number of monsters that are on the level, bigger the number the less monsters spawn.
@@ -130,7 +130,7 @@ public class Level {
 		this.w = w;
 		this.h = h;
 		this.seed = seed;
-		byte[][] maps; // Multidimensional array (an array within a array), used for the map
+		short[][] maps; // Multidimensional array (an array within a array), used for the map
 		
 		if (level != -4 && level != 0)
 			monsterDensity = 8;
@@ -139,8 +139,8 @@ public class Level {
 		
 		if(!makeWorld) {
 			int arrsize = w * h;
-			tiles = new byte[arrsize];
-			data = new byte[arrsize];
+			tiles = new short[arrsize];
+			data = new short[arrsize];
 			return;
 		}
 		
@@ -581,7 +581,7 @@ public class Level {
 			System.out.println("Client requested a tile update for the " + t.name + " tile at " + x + "," + y);
 		} else {
 			tiles[x + y * w] = t.id;
-			data[x + y * w] = (byte) dataVal;
+			data[x + y * w] = (short) dataVal;
 		}
 		
 		if(Game.isValidServer())
@@ -595,7 +595,7 @@ public class Level {
 	
 	public void setData(int x, int y, int val) {
 		if (x < 0 || y < 0 || x >= w || y >= h) return;
-		data[x + y * w] = (byte) val;
+		data[x + y * w] = (short) val;
 	}
 	
 	public void add(Entity e) { if(e==null) return; add(e, e.x, e.y); }

--- a/src/main/java/minicraft/level/LevelGen.java
+++ b/src/main/java/minicraft/level/LevelGen.java
@@ -139,14 +139,14 @@ public class LevelGen {
 			int[] count = new int[256];
 			
 			for (int i = 0; i < w * h; i++) {
-				count[result[0][i] & 0xff]++;
+				count[result[0][i] & 0xffff]++;
 			}
-			if (count[Tiles.get("rock").id & 0xff] < 100) continue;
-			if (count[Tiles.get("sand").id & 0xff] < 100) continue;
-			if (count[Tiles.get("grass").id & 0xff] < 100) continue;
-			if (count[Tiles.get("tree").id & 0xff] < 100) continue;
+			if (count[Tiles.get("rock").id & 0xffff] < 100) continue;
+			if (count[Tiles.get("sand").id & 0xffff] < 100) continue;
+			if (count[Tiles.get("grass").id & 0xffff] < 100) continue;
+			if (count[Tiles.get("tree").id & 0xffff] < 100) continue;
 			
-			if (count[Tiles.get("Stairs Down").id & 0xff] < w / 21)
+			if (count[Tiles.get("Stairs Down").id & 0xffff] < w / 21)
 				continue; // Size 128 = 6 stairs min
 			
 			return result;
@@ -162,13 +162,13 @@ public class LevelGen {
 			int[] count = new int[256];
 			
 			for (int i = 0; i < w * h; i++) {
-				count[result[0][i] & 0xff]++;
+				count[result[0][i] & 0xffff]++;
 			}
-			if (count[Tiles.get("rock").id & 0xff] < 100) continue;
-			if (count[Tiles.get("dirt").id & 0xff] < 100) continue;
-			if (count[(Tiles.get("iron Ore").id & 0xff) + depth - 1] < 20) continue;
+			if (count[Tiles.get("rock").id & 0xffff] < 100) continue;
+			if (count[Tiles.get("dirt").id & 0xffff] < 100) continue;
+			if (count[(Tiles.get("iron Ore").id & 0xffff) + depth - 1] < 20) continue;
 			
-			if (depth < 3 && count[Tiles.get("Stairs Down").id & 0xff] < w / 32)
+			if (depth < 3 && count[Tiles.get("Stairs Down").id & 0xffff] < w / 32)
 				continue; // Size 128 = 4 stairs min
 			
 			return result;
@@ -185,10 +185,10 @@ public class LevelGen {
 			int[] count = new int[256];
 			
 			for (int i = 0; i < w * h; i++) {
-				count[result[0][i] & 0xff]++;
+				count[result[0][i] & 0xffff]++;
 			}
-			if (count[Tiles.get("Obsidian").id & 0xff] < 100) continue;
-			if (count[Tiles.get("Obsidian Wall").id & 0xff] < 100) continue;
+			if (count[Tiles.get("Obsidian").id & 0xffff] < 100) continue;
+			if (count[Tiles.get("Obsidian Wall").id & 0xffff] < 100) continue;
 			
 			return result;
 			
@@ -204,10 +204,10 @@ public class LevelGen {
 			int[] count = new int[256];
 			
 			for (int i = 0; i < w * h; i++) {
-				count[result[0][i] & 0xff]++;
+				count[result[0][i] & 0xffff]++;
 			}
-			if (count[Tiles.get("cloud").id & 0xff] < 2000) continue;
-			if (count[Tiles.get("Stairs Down").id & 0xff] < w / 64)
+			if (count[Tiles.get("cloud").id & 0xffff] < 2000) continue;
+			if (count[Tiles.get("Stairs Down").id & 0xffff] < w / 64)
 				continue; // size 128 = 2 stairs min
 			
 			return result;
@@ -594,7 +594,7 @@ public class LevelGen {
 					int yy = y + random.nextInt(5) - random.nextInt(5);
 					if (xx >= r && yy >= r && xx < w - r && yy < h - r) {
 						if (map[xx + yy * w] == Tiles.get("rock").id) {
-							map[xx + yy * w] = (short) ((Tiles.get("iron Ore").id & 0xff) + depth - 1);
+							map[xx + yy * w] = (short) ((Tiles.get("iron Ore").id & 0xffff) + depth - 1);
 						}
 					}
 				}
@@ -603,7 +603,7 @@ public class LevelGen {
 					int yy = y + random.nextInt(3) - random.nextInt(2);
 					if (xx >= r && yy >= r && xx < w - r && yy < h - r) {
 						if (map[xx + yy * w] == Tiles.get("rock").id) {
-							map[xx + yy * w] = (short) (Tiles.get("Lapis").id & 0xff);
+							map[xx + yy * w] = (short) (Tiles.get("Lapis").id & 0xffff);
 						}
 					}
 				}
@@ -620,8 +620,8 @@ public class LevelGen {
 						
 						Structure.dungeonLock.draw(map, xx, yy, w);
 						
-						/// The "& 0xff" is a common way to convert a short to an unsigned int, which basically prevents negative values... except... this doesn't do anything if you flip it back to a short again...
-						map[xx + yy * w] = (short) (Tiles.get("Stairs Down").id & 0xff);
+						/// The "& 0xffff" is a common way to convert a short to an unsigned int, which basically prevents negative values... except... this doesn't do anything if you flip it back to a short again...
+						map[xx + yy * w] = (short) (Tiles.get("Stairs Down").id & 0xffff);
 					}
 				}
 			}
@@ -783,11 +783,11 @@ public class LevelGen {
 					if (map[i] == Tiles.get("tree").id) pixels[i] = 0x003000;
 					if (map[i] == Tiles.get("Obsidian Wall").id) pixels[i] = 0x0aa0a0;
 					if (map[i] == Tiles.get("Obsidian").id) pixels[i] = 0x000000;
-					if (map[i] == Tiles.get("lava").id) pixels[i] = 0xff2020;
+					if (map[i] == Tiles.get("lava").id) pixels[i] = 0xffff2020;
 					if (map[i] == Tiles.get("cloud").id) pixels[i] = 0xa0a0a0;
-					if (map[i] == Tiles.get("Stairs Down").id) pixels[i] = 0xffffff;
-					if (map[i] == Tiles.get("Stairs Up").id) pixels[i] = 0xffffff;
-					if (map[i] == Tiles.get("Cloud Cactus").id) pixels[i] = 0xff00ff;
+					if (map[i] == Tiles.get("Stairs Down").id) pixels[i] = 0xffffffff;
+					if (map[i] == Tiles.get("Stairs Up").id) pixels[i] = 0xffffffff;
+					if (map[i] == Tiles.get("Cloud Cactus").id) pixels[i] = 0xffff00ff;
 				}
 			}
 			img.setRGB(0, 0, w, h, pixels, 0, w);

--- a/src/main/java/minicraft/level/LevelGen.java
+++ b/src/main/java/minicraft/level/LevelGen.java
@@ -114,7 +114,7 @@ public class LevelGen {
 	}
 	
 	@Nullable
-	static byte[][] createAndValidateMap(int w, int h, int level) {
+	static short[][] createAndValidateMap(int w, int h, int level) {
 		worldSeed = WorldGenDisplay.getSeed();
 		
 		if (level == 1)
@@ -131,10 +131,10 @@ public class LevelGen {
 		return null;
 	}
 	
-	private static byte[][] createAndValidateTopMap(int w, int h) {
+	private static short[][] createAndValidateTopMap(int w, int h) {
 		random.setSeed(worldSeed);
 		do {
-			byte[][] result = createTopMap(w, h);
+			short[][] result = createTopMap(w, h);
 			
 			int[] count = new int[256];
 			
@@ -154,10 +154,10 @@ public class LevelGen {
 		} while (true);
 	}
 	
-	private static byte[][] createAndValidateUndergroundMap(int w, int h, int depth) {
+	private static @Nullable short[][] createAndValidateUndergroundMap(int w, int h, int depth) {
 		random.setSeed(worldSeed);
 		do {
-			byte[][] result = createUndergroundMap(w, h, depth);
+			short[][] result = createUndergroundMap(w, h, depth);
 			
 			int[] count = new int[256];
 			
@@ -176,11 +176,11 @@ public class LevelGen {
 		} while (true);
 	}
 	
-	private static byte[][] createAndValidateDungeon(int w, int h) {
+	private static short[][] createAndValidateDungeon(int w, int h) {
 		random.setSeed(worldSeed);
 		
 		do {
-			byte[][] result = createDungeon(w, h);
+			short[][] result = createDungeon(w, h);
 			
 			int[] count = new int[256];
 			
@@ -195,11 +195,11 @@ public class LevelGen {
 		} while (true);
 	}
 
-	private static byte[][] createAndValidateSkyMap(int w, int h) {
+	private static @Nullable short[][] createAndValidateSkyMap(int w, int h) {
 		random.setSeed(worldSeed);
 		
 		do {
-			byte[][] result = createSkyMap(w, h);
+			short[][] result = createSkyMap(w, h);
 			
 			int[] count = new int[256];
 			
@@ -215,7 +215,7 @@ public class LevelGen {
 		} while (true);
 	}
 	
-	private static byte[][] createTopMap(int w, int h) { // Create surface map
+	private static short[][] createTopMap(int w, int h) { // Create surface map
 		// creates a bunch of value maps, some with small size...
 		LevelGen mnoise1 = new LevelGen(w, h, 16);
 		LevelGen mnoise2 = new LevelGen(w, h, 16);
@@ -225,8 +225,8 @@ public class LevelGen {
 		LevelGen noise1 = new LevelGen(w, h, 32);
 		LevelGen noise2 = new LevelGen(w, h, 32);
 		
-		byte[] map = new byte[w * h];
-		byte[] data = new byte[w * h];
+		short[] map = new short[w * h];
+		short[] data = new short[w * h];
 
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
@@ -427,7 +427,7 @@ public class LevelGen {
 				if (xx >= 0 && yy >= 0 && xx < w && yy < h) {
 					if (map[xx + yy * w] == Tiles.get("grass").id) {
 						map[xx + yy * w] = Tiles.get("flower").id;
-						data[xx + yy * w] = (byte) (col + random.nextInt(4) * 16); // Data determines which way the flower faces
+						data[xx + yy * w] = (short) (col + random.nextInt(4) * 16); // Data determines which way the flower faces
 					}
 				}
 			}
@@ -475,15 +475,15 @@ public class LevelGen {
 		//average /= w*h;
 		//System.out.println(average);
 		
-		return new byte[][]{map, data};
+		return new short[][]{map, data};
 	}
 	
-	private static byte[][] createDungeon(int w, int h) {
+	private static short[][] createDungeon(int w, int h) {
 		LevelGen noise1 = new LevelGen(w, h, 8);
 		LevelGen noise2 = new LevelGen(w, h, 8);
 		
-		byte[] map = new byte[w * h];
-		byte[] data = new byte[w * h];
+		short[] map = new short[w * h];
+		short[] data = new short[w * h];
 		
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
@@ -522,10 +522,10 @@ public class LevelGen {
 			Structure.lavaPool.draw(map, x, y, w);
 		}
 		
-		return new byte[][]{map, data};
+		return new short[][]{map, data};
 	}
 	
-	private static byte[][] createUndergroundMap(int w, int h, int depth) {
+	private static short[][] createUndergroundMap(int w, int h, int depth) {
 		LevelGen mnoise1 = new LevelGen(w, h, 16);
 		LevelGen mnoise2 = new LevelGen(w, h, 16);
 		LevelGen mnoise3 = new LevelGen(w, h, 16);
@@ -541,8 +541,8 @@ public class LevelGen {
 		LevelGen noise1 = new LevelGen(w, h, 32);
 		LevelGen noise2 = new LevelGen(w, h, 32);
 		
-		byte[] map = new byte[w * h];
-		byte[] data = new byte[w * h];
+		short[] map = new short[w * h];
+		short[] data = new short[w * h];
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
 				int i = x + y * w;
@@ -594,7 +594,7 @@ public class LevelGen {
 					int yy = y + random.nextInt(5) - random.nextInt(5);
 					if (xx >= r && yy >= r && xx < w - r && yy < h - r) {
 						if (map[xx + yy * w] == Tiles.get("rock").id) {
-							map[xx + yy * w] = (byte) ((Tiles.get("iron Ore").id & 0xff) + depth - 1);
+							map[xx + yy * w] = (short) ((Tiles.get("iron Ore").id & 0xff) + depth - 1);
 						}
 					}
 				}
@@ -603,7 +603,7 @@ public class LevelGen {
 					int yy = y + random.nextInt(3) - random.nextInt(2);
 					if (xx >= r && yy >= r && xx < w - r && yy < h - r) {
 						if (map[xx + yy * w] == Tiles.get("rock").id) {
-							map[xx + yy * w] = (byte) (Tiles.get("Lapis").id & 0xff);
+							map[xx + yy * w] = (short) (Tiles.get("Lapis").id & 0xff);
 						}
 					}
 				}
@@ -620,8 +620,8 @@ public class LevelGen {
 						
 						Structure.dungeonLock.draw(map, xx, yy, w);
 						
-						/// The "& 0xff" is a common way to convert a byte to an unsigned int, which basically prevents negative values... except... this doesn't do anything if you flip it back to a byte again...
-						map[xx + yy * w] = (byte) (Tiles.get("Stairs Down").id & 0xff);
+						/// The "& 0xff" is a common way to convert a short to an unsigned int, which basically prevents negative values... except... this doesn't do anything if you flip it back to a short again...
+						map[xx + yy * w] = (short) (Tiles.get("Stairs Down").id & 0xff);
 					}
 				}
 			}
@@ -649,15 +649,15 @@ public class LevelGen {
 			}
 		}
 		
-		return new byte[][]{map, data};
+		return new short[][]{map, data};
 	}
 	
-	private static byte[][] createSkyMap(int w, int h) {
+	private static short[][] createSkyMap(int w, int h) {
 		LevelGen noise1 = new LevelGen(w, h, 8);
 		LevelGen noise2 = new LevelGen(w, h, 8);
 		
-		byte[] map = new byte[w * h];
-		byte[] data = new byte[w * h];
+		short[] map = new short[w * h];
+		short[] data = new short[w * h];
 		
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
@@ -717,7 +717,7 @@ public class LevelGen {
 			if (count >= w / 64) break;
 		}
 		
-		return new byte[][]{map, data};
+		return new short[][]{map, data};
 	}
 	
 	public static void main(String[] args) {
@@ -760,10 +760,10 @@ public class LevelGen {
 			int lvl = maplvls[idx++ % maplvls.length];
 			if (lvl > 1 || lvl < -4) continue;
 			
-			byte[][] fullmap = LevelGen.createAndValidateMap(w, h, lvl);
+			short[][] fullmap = LevelGen.createAndValidateMap(w, h, lvl);
 			
 			if (fullmap == null) continue;
-			byte[] map = fullmap[0];
+			short[] map = fullmap[0];
 			
 			BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
 			int[] pixels = new int[w * h];

--- a/src/main/java/minicraft/level/Structure.java
+++ b/src/main/java/minicraft/level/Structure.java
@@ -40,7 +40,7 @@ public class Structure {
 			 level.add(furniture.get(p).clone(), xt+p.x, yt+p.y, true);
 	}
 
-	public void draw(byte[] map, int xt, int yt, int mapWidth) {
+	public void draw(short[] map, int xt, int yt, int mapWidth) {
 		for (TilePoint p: tiles)
 			map[(xt + p.x) + (yt + p.y) * mapWidth] = p.t.id;
 	}

--- a/src/main/java/minicraft/level/tile/Tile.java
+++ b/src/main/java/minicraft/level/tile/Tile.java
@@ -40,7 +40,7 @@ public abstract class Tile {
 	
 	public final String name;
 	
-	public byte id;
+	public short id;
 	
 	public boolean connectsToGrass = false;
 	public boolean connectsToSand = false;

--- a/src/main/java/minicraft/level/tile/Tiles.java
+++ b/src/main/java/minicraft/level/tile/Tiles.java
@@ -19,7 +19,7 @@ public final class Tiles {
 		Logger.debug("Initializing tile list...");
 		
 		// 
-		for (int i = 0; i < 65536; i++)
+		for (int i = 0; i < 32768; i++)
 			tiles.add(null);
 
 		tiles.set(0, new GrassTile("Grass"));
@@ -73,7 +73,7 @@ public final class Tiles {
 		tiles.set(46, new DecorTile(Tile.Material.Obsidian));
 
 		// WARNING: don't use this tile for anything!
-		tiles.set(255, new ConnectTile());
+		tiles.set(256, new ConnectTile());
 		
 		for(int i = 0; i < tiles.size(); i++) {
 			if(tiles.get(i) == null) continue;
@@ -85,11 +85,11 @@ public final class Tiles {
 	protected static void add(int id, Tile tile) {
 		tiles.set(id, tile);
 		System.out.println("Adding " + tile.name + " to tile list with id " + id);
-		tile.id = (byte) id;
+		tile.id = (short) id;
 	}
 
 	static {
-		for(int i = 0; i < 65536; i++)
+		for(int i = 0; i < 32768; i++)
 			oldids.add(null);
 		
 		oldids.set(0, "grass");
@@ -206,7 +206,7 @@ public final class Tiles {
 		if(name.contains("_")) {
 			name = name.substring(0, name.indexOf("_"));
 		}
-		
+
 		for(Tile t: tiles) {
 			if(t == null) continue;
 			if(t.name.equals(name)) {
@@ -227,16 +227,16 @@ public final class Tiles {
 		overflowCheck = 0;
 		return getting;
 	}
-	
+
 	public static Tile get(int id) {
 		//System.out.println("Requesting tile by id: " + id);
-		if(id < 0) id += 65536;
-		
+		if(id < 0) id += 32768;
+
 		if(tiles.get(id) != null) {
 			return tiles.get(id);
 		}
-		else if(id >= 32768) {
-			return tiles.get((short) id);
+		else if(id >= 32767) {
+			return TorchTile.getTorchTile(get(id - 32767));
 		}
 		else {
 			System.out.println("TILES.GET: Unknown tile id requested: " + id);

--- a/src/main/java/minicraft/level/tile/Tiles.java
+++ b/src/main/java/minicraft/level/tile/Tiles.java
@@ -19,7 +19,7 @@ public final class Tiles {
 		Logger.debug("Initializing tile list...");
 		
 		// 
-		for (int i = 0; i < 256; i++)
+		for (int i = 0; i < 65536; i++)
 			tiles.add(null);
 
 		tiles.set(0, new GrassTile("Grass"));
@@ -89,7 +89,7 @@ public final class Tiles {
 	}
 
 	static {
-		for(int i = 0; i < 256; i++)
+		for(int i = 0; i < 65536; i++)
 			oldids.add(null);
 		
 		oldids.set(0, "grass");
@@ -230,13 +230,13 @@ public final class Tiles {
 	
 	public static Tile get(int id) {
 		//System.out.println("Requesting tile by id: " + id);
-		if(id < 0) id += 256;
+		if(id < 0) id += 65536;
 		
 		if(tiles.get(id) != null) {
 			return tiles.get(id);
 		}
-		else if(id >= 128) {
-			return TorchTile.getTorchTile(get(id-128));
+		else if(id >= 32768) {
+			return tiles.get((short) id);
 		}
 		else {
 			System.out.println("TILES.GET: Unknown tile id requested: " + id);

--- a/src/main/java/minicraft/level/tile/TorchTile.java
+++ b/src/main/java/minicraft/level/tile/TorchTile.java
@@ -16,8 +16,8 @@ public class TorchTile extends Tile {
 	private Tile onType;
 	
 	public static TorchTile getTorchTile(Tile onTile) {
-		int id = onTile.id & 0xFF;
-		if(id < 128) id += 128;
+		int id = onTile.id & 0xFFFF;
+		if(id < 16384) id += 16384;
 		else System.out.println("Tried to place torch on torch tile...");
 		
 		if(Tiles.containsTile(id))

--- a/src/main/java/minicraft/network/MinicraftServer.java
+++ b/src/main/java/minicraft/network/MinicraftServer.java
@@ -490,7 +490,7 @@ public class MinicraftServer extends Thread implements MinicraftProtocol {
 				
 				// if it's the same level, it will cancel out.
 				
-				byte[] tiledata = new byte[World.levels[levelidx].tiles.length*2];
+				short[] tiledata = new short[World.levels[levelidx].tiles.length*2];
 				for (int i = 0; i < tiledata.length/2 - 1; i++) {
 					tiledata[i*2] = World.levels[levelidx].tiles[i];
 					tiledata[i*2+1] = World.levels[levelidx].data[i];
@@ -498,7 +498,7 @@ public class MinicraftServer extends Thread implements MinicraftProtocol {
 				serverThread.cachePacketTypes(InputType.tileUpdates);
 				
 				StringBuilder tiledataString = new StringBuilder();
-				for (byte b: tiledata) {
+				for (short b: tiledata) {
 					tiledataString.append(b).append(",");
 				}
 				serverThread.sendData(InputType.TILES, tiledataString.substring(0, tiledataString.length()-1));

--- a/src/main/java/minicraft/saveload/LegacyLoad.java
+++ b/src/main/java/minicraft/saveload/LegacyLoad.java
@@ -215,15 +215,15 @@ public class LegacyLoad {
 			int lvldepth = Integer.parseInt(data.get(2));
 			Settings.set("size", lvlw);
 
-			byte[] tiles = new byte[lvlw * lvlh];
-			byte[] tdata = new byte[lvlw * lvlh];
+			short[] tiles = new short[lvlw * lvlh];
+			short[] tdata = new short[lvlw * lvlh];
 			
 			for (int x = 0; x < lvlw - 1; x++) {
 				for (int y = 0; y < lvlh - 1; y++) {
 					int tileArrIdx = y + x * lvlw;
 					int tileidx = x + y * lvlw; // The tiles are saved with x outer loop, and y inner loop, meaning that the list reads down, then right one, rather than right, then down one.
 					tiles[tileArrIdx] = Tiles.get(Tiles.oldids.get(Integer.parseInt(data.get(tileidx + 3)))).id;
-					tdata[tileArrIdx] = Byte.parseByte(extradata.get(tileidx));
+					tdata[tileArrIdx] = Short.parseShort(extradata.get(tileidx));
 				}
 			}
 

--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -432,8 +432,8 @@ public class Load {
 			long seed = hasSeed ? Long.parseLong(data.get(2)) : 0;
 			Settings.set("size", lvlw);
 			
-			byte[] tiles = new byte[lvlw * lvlh];
-			byte[] tdata = new byte[lvlw * lvlh];
+			short[] tiles = new short[lvlw * lvlh];
+			short[] tdata = new short[lvlw * lvlh];
 			
 			for (int x = 0; x < lvlw; x++) {
 				for (int y = 0; y < lvlh; y++) {
@@ -477,7 +477,7 @@ public class Load {
 							tilename = "Gem Ore";
 					}
 					tiles[tileArrIdx] = Tiles.get(tilename).id;
-					tdata[tileArrIdx] = Byte.parseByte(extradata.get(tileidx));
+					tdata[tileArrIdx] = Short.parseShort(extradata.get(tileidx));
 				}
 			}
 			


### PR DESCRIPTION
Still no method of converting old torch tiles in old worlds, since torch tiles now start after 16384.