### PR TITLE
Added multiple screen resolutions

### DIFF
--- a/src/main/java/minicraft/core/Game.java
+++ b/src/main/java/minicraft/core/Game.java
@@ -122,9 +122,9 @@ public class Game {
 		player.eid = 0;
 		new Load(true); // This loads any saved preferences.
 
+		Renderer.setScreenResolution(); // Sets the screen resolution.
 
 		setMenu(new TitleDisplay()); // Sets menu to the title screen.
-
 
 		Initializer.createAndDisplayFrame();
 		

--- a/src/main/java/minicraft/core/Renderer.java
+++ b/src/main/java/minicraft/core/Renderer.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 
+import minicraft.core.io.Settings;
 import minicraft.entity.furniture.Bed;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Color;
@@ -35,8 +36,9 @@ import javax.imageio.ImageIO;
 public class Renderer extends Game {
 	private Renderer() {}
 	
-	public static final int HEIGHT = 192;
-	public static final int WIDTH = 288;
+	public static final int MAX_SIZE = 288;
+	public static int HEIGHT;
+	public static int WIDTH;
 	static float SCALE = 3;
 	
 	public static Screen screen; // Creates the main screen
@@ -78,7 +80,36 @@ public class Renderer extends Game {
 		return new SpriteSheet[] { itemSheet, tileSheet, entitySheet, guiSheet, skinsSheet };
 	}
 
-	static void initScreen() {
+	public static void setScreenResolution() {
+		int width = 0;
+		int height = 0;
+
+		switch ((String) Settings.get("screenresolution")) {
+			case "Native":
+				java.awt.Dimension size = java.awt.Toolkit.getDefaultToolkit().getScreenSize();
+				width = (int) size.getWidth();
+				height = (int) size.getHeight();
+				break;
+			
+			case "4x3":
+				width = 4;
+				height = 3;
+				break;
+
+			case "16x9":
+				width = 16;
+				height = 9;
+				break;
+			default:
+				break;
+		}
+
+		double s = Math.min((double) Renderer.MAX_SIZE/width, (double) Renderer.MAX_SIZE/height);
+		Renderer.HEIGHT = (int) (height * s);
+		Renderer.WIDTH = (int) (width * s);
+	}
+
+	public static void initScreen() {
 		image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
 		pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
 

--- a/src/main/java/minicraft/core/io/Settings.java
+++ b/src/main/java/minicraft/core/io/Settings.java
@@ -13,6 +13,7 @@ public class Settings {
 	private static final HashMap<String, ArrayEntry> options = new HashMap<>();
 	
 	static {
+		options.put("screenresolution", new ArrayEntry<>("Screen Resolution", "4x3", "16x9", "Native"));
 		options.put("fps", new RangeEntry("Max FPS", 10, 300, getRefreshRate())); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
 		options.put("diff", new ArrayEntry<>("Difficulty", "Easy", "Normal", "Hard"));
 		options.get("diff").setSelection(1);

--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -338,6 +338,7 @@ public class Load {
 		Settings.set("sound", json.getBoolean("sound"));
 		Settings.set("autosave", json.getBoolean("autosave"));
 		Settings.set("diff", json.has("diff") ? json.getString("diff") : "Normal");
+		Settings.set("screenresolution", json.has("screenresolution") ? json.getString("screenresolution") : "4x3");
 		Settings.set("fps", json.getInt("fps"));
 
 		if (prefVer.compareTo(new Version("2.1.0-dev1")) > 0) {

--- a/src/main/java/minicraft/saveload/Save.java
+++ b/src/main/java/minicraft/saveload/Save.java
@@ -177,6 +177,7 @@ public class Save {
 		json.put("sound", String.valueOf(Settings.get("sound")));
 		json.put("autosave", String.valueOf(Settings.get("autosave")));
 		json.put("fps", String.valueOf(Settings.get("fps")));
+		json.put("screenresolution", String.valueOf(Settings.get("screenresolution")));
 		json.put("lang", Localization.getSelectedLocale().toLanguageTag());
 		json.put("skinIdx", String.valueOf(SkinDisplay.getSelectedSkinIndex()));
 		json.put("savedIP", MultiplayerDisplay.savedIP);

--- a/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
+++ b/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
@@ -3,6 +3,9 @@ package minicraft.screen;
 import minicraft.core.Game;
 import minicraft.core.io.Localization;
 import minicraft.core.io.Settings;
+import minicraft.gfx.Color;
+import minicraft.gfx.Font;
+import minicraft.gfx.Screen;
 import minicraft.saveload.Save;
 import minicraft.screen.entry.SelectEntry;
 
@@ -11,6 +14,7 @@ public class OptionsMainMenuDisplay extends Display {
     public OptionsMainMenuDisplay() {
         super(true, new Menu.Builder(false, 6, RelPos.LEFT,
             Settings.getEntry("fps"),
+            Settings.getEntry("screenresolution"),
             Settings.getEntry("sound"),
             new SelectEntry("Change Key Bindings", () -> Game.setMenu(new KeyInputDisplay())),
             Settings.getEntry("language")
@@ -18,6 +22,14 @@ public class OptionsMainMenuDisplay extends Display {
             .setTitle("Main Menu Options")
             .createMenu()
         );
+    }
+
+    @Override
+	public void render(Screen screen) {
+		super.render(screen);
+        
+		// Warning users about screen resoluton requiring a restart
+		Font.drawCentered("Some settings may require a restart", screen, Screen.h-20, Color.RED);
     }
 
     @Override


### PR DESCRIPTION
Is the start of dealing with #277. We probably need to rethink some of the menus but this works good enough as a start for now.

The default of 4x3 makes sense until we adjust menus for both 4x3 and 16x9.

The "Native" screen resolution option adjusts the screen resolution to that of the main monitor. On a Mac, it'd be 16x10. On most monitors, it'd be 16x9.