### PR TITLE
Fix Interaction of active item

### DIFF
--- a/src/main/java/minicraft/entity/mob/Player.java
+++ b/src/main/java/minicraft/entity/mob/Player.java
@@ -3,7 +3,6 @@ package minicraft.entity.mob;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import minicraft.screen.*;
 import org.jetbrains.annotations.Nullable;
@@ -579,7 +578,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			if (t.x >= 0 && t.y >= 0 && t.x < level.w && t.y < level.h) {
 
 				// Get any entities (except dropped items) on the tile.
-				List<Entity> tileEntities = level.getEntitiesInTiles(t.x, t.y, t.x, t.y, false, ItemEntity.class).stream().filter(e -> !(e instanceof Particle)).collect(Collectors.toList());
+				List<Entity> tileEntities = level.getEntitiesInTiles(t.x, t.y, t.x, t.y, false, ItemEntity.class, Particle.class);
 
 				// If there are no other entities than us on the tile.
 				if (tileEntities.size() == 0 || tileEntities.size() == 1 && tileEntities.get(0) == this) {

--- a/src/main/java/minicraft/entity/mob/Player.java
+++ b/src/main/java/minicraft/entity/mob/Player.java
@@ -3,6 +3,7 @@ package minicraft.entity.mob;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import minicraft.screen.*;
 import org.jetbrains.annotations.Nullable;
@@ -23,6 +24,7 @@ import minicraft.entity.furniture.Bed;
 import minicraft.entity.furniture.DeathChest;
 import minicraft.entity.furniture.Furniture;
 import minicraft.entity.furniture.Tnt;
+import minicraft.entity.particle.Particle;
 import minicraft.entity.particle.TextParticle;
 import minicraft.gfx.Color;
 import minicraft.gfx.MobSprite;
@@ -577,7 +579,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			if (t.x >= 0 && t.y >= 0 && t.x < level.w && t.y < level.h) {
 
 				// Get any entities (except dropped items) on the tile.
-				List<Entity> tileEntities = level.getEntitiesInTiles(t.x, t.y, t.x, t.y, false, ItemEntity.class);
+				List<Entity> tileEntities = level.getEntitiesInTiles(t.x, t.y, t.x, t.y, false, ItemEntity.class).stream().filter(e -> !(e instanceof Particle)).collect(Collectors.toList());
 
 				// If there are no other entities than us on the tile.
 				if (tileEntities.size() == 0 || tileEntities.size() == 1 && tileEntities.get(0) == this) {


### PR DESCRIPTION
This includes all the tile interaction (e.g. TreeTile, OreTile, RockTile, etc.).
Reason: The List of the entities of the tile includes particles. Particles need time to be disappeared; potential cooldown occurred.
Fixes #176