### PR TITLE
Menus fixes for the aspect ratio

### DIFF
--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -454,7 +454,7 @@ public class Level {
 		int xo = xScroll >> 4; // Latches to the nearest tile coordinate
 		int yo = yScroll >> 4;
 		int w = (Screen.w) >> 4; // There used to be a "+15" as in below method
-		int h = (Screen.h) >> 4;
+		int h = (Screen.h + 8) >> 4; // Fix: + 8 lowers the rendering of the level a bit below the screen so that it is not affected by the aspect ratio
 		screen.setOffset(xScroll, yScroll);
 		for (int y = yo; y <= h + yo; y++) {
 			for (int x = xo; x <= w + xo; x++) {

--- a/src/main/java/minicraft/screen/BookDisplay.java
+++ b/src/main/java/minicraft/screen/BookDisplay.java
@@ -18,7 +18,7 @@ public class BookDisplay extends Display {
 	private static final String defaultBook = "This book has no text.";
 	
 	private static final int spacing = 3;
-	private static final int minX = 15, maxX = 15+8 * 32, minY = 8*5, maxY = 8*5 + 8*16;
+	private static int minX = 15, maxX = 15+8 * 32, minY = 8*5, maxY = 8*5 + 8*16;
 
 	// First array is page and second is line.
 	private String[][] lines;
@@ -36,6 +36,12 @@ public class BookDisplay extends Display {
 		if (book == null) {
 			book = defaultBook;
 			hasTitle = false;
+		}
+		
+		if (OptionsMainMenuDisplay.originalAspectRatio == "16x9") {
+			maxY = 8*5 + 8*12; // 16x9? less height
+		} else {
+			maxY = 8*5 + 8*16;
 		}
 
 		this.hasTitle = hasTitle;
@@ -88,8 +94,10 @@ public class BookDisplay extends Display {
 	
 	@Override
 	public void tick(InputHandler input) {
-		if (input.getKey("menu").clicked || input.getKey("exit").clicked)
-			Game.exitDisplay(); // This is what closes the book; TODO if books were editable, I would probably remake the book here with the edited pages.
+		if (input.getKey("menu").clicked || input.getKey("exit").clicked){
+			// This is what closes the book; TODO if books were editable, I would probably remake the book here with the edited pages
+			Game.exitDisplay();
+		}
 		if (input.getKey("cursor-left").clicked) turnPage(-1); // This is what turns the page back
 		if (input.getKey("cursor-right").clicked) turnPage(1); // This is what turns the page forward
 	}

--- a/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
+++ b/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
@@ -1,6 +1,8 @@
 package minicraft.screen;
 
 import minicraft.core.Game;
+import minicraft.core.Initializer;
+import minicraft.core.Renderer;
 import minicraft.core.io.InputHandler;
 import minicraft.core.io.Localization;
 import minicraft.core.io.Settings;
@@ -13,7 +15,7 @@ import minicraft.screen.entry.StringEntry;
 
 public class OptionsMainMenuDisplay extends Display {
 
-    String originalAspectRatio = (String) Settings.get("aspectratio");
+    public static String originalAspectRatio = (String) Settings.get("aspectratio");
 
     public OptionsMainMenuDisplay() {
         super(true);
@@ -25,7 +27,6 @@ public class OptionsMainMenuDisplay extends Display {
             Settings.getEntry("language"),
             Settings.getEntry("aspectratio"),
             new BlankEntry(),
-            new SelectEntry("minicraft.display.skin", () -> Game.setDisplay(new SkinDisplay())),
             new SelectEntry("Resource packs", () -> Game.setDisplay(new ResourcePackDisplay())))
             .setTitle("Main Menu Options")
             .createMenu();

--- a/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
+++ b/src/main/java/minicraft/screen/OptionsMainMenuDisplay.java
@@ -7,6 +7,7 @@ import minicraft.core.io.Settings;
 import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
 import minicraft.saveload.Save;
+import minicraft.screen.entry.BlankEntry;
 import minicraft.screen.entry.SelectEntry;
 import minicraft.screen.entry.StringEntry;
 
@@ -23,6 +24,8 @@ public class OptionsMainMenuDisplay extends Display {
             new SelectEntry("Change Key Bindings", () -> Game.setDisplay(new KeyInputDisplay())),
             Settings.getEntry("language"),
             Settings.getEntry("aspectratio"),
+            new BlankEntry(),
+            new SelectEntry("minicraft.display.skin", () -> Game.setDisplay(new SkinDisplay())),
             new SelectEntry("Resource packs", () -> Game.setDisplay(new ResourcePackDisplay())))
             .setTitle("Main Menu Options")
             .createMenu();

--- a/src/main/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerInvDisplay.java
@@ -42,7 +42,7 @@ public class PlayerInvDisplay extends Display {
 		String text = "(" + Game.input.getMapping("SEARCHER-BAR") + ") " + Localization.getLocalized("to search.");
 		
 		// Position the search tip according to the aspect ratio
-		if (Settings.get("aspectratio") == "16x9") {
+		if (OptionsMainMenuDisplay.originalAspectRatio == "16x9") {
 			Font.draw(text, screen, 12, Screen.h/ 2 + 16, Color.WHITE);
 		} else {
 			Font.draw(text, screen, 12, Screen.h/ 2 - 10, Color.WHITE);

--- a/src/main/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerInvDisplay.java
@@ -39,6 +39,6 @@ public class PlayerInvDisplay extends Display {
 
 		// Searcher help text
 		String text = "(" + Game.input.getMapping("SEARCHER-BAR") + ") " + Localization.getLocalized("to search.");
-		Font.draw(text, screen, 16, Screen.h / 2 + 2, Color.WHITE);
+		Font.draw(text, screen, 16, Screen.h/ 2, Color.WHITE);
 	}
 }

--- a/src/main/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerInvDisplay.java
@@ -3,6 +3,7 @@ package minicraft.screen;
 import minicraft.core.Game;
 import minicraft.core.io.InputHandler;
 import minicraft.core.io.Localization;
+import minicraft.core.io.Settings;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Color;
 import minicraft.gfx.Font;
@@ -39,6 +40,13 @@ public class PlayerInvDisplay extends Display {
 
 		// Searcher help text
 		String text = "(" + Game.input.getMapping("SEARCHER-BAR") + ") " + Localization.getLocalized("to search.");
-		Font.draw(text, screen, 16, Screen.h/ 2, Color.WHITE);
+		
+		// Position the search tip according to the aspect ratio
+		if (Settings.get("aspectratio") == "16x9") {
+			Font.draw(text, screen, 12, Screen.h/ 2 + 16, Color.WHITE);
+		} else {
+			Font.draw(text, screen, 12, Screen.h/ 2 - 10, Color.WHITE);
+		}
+		
 	}
 }

--- a/src/main/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/main/java/minicraft/screen/ResourcePackDisplay.java
@@ -15,6 +15,7 @@ import minicraft.core.Renderer;
 import minicraft.core.io.Localization;
 import minicraft.gfx.Color;
 import minicraft.gfx.Font;
+import minicraft.gfx.Point;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteSheet;
 import minicraft.screen.entry.ListEntry;
@@ -54,7 +55,10 @@ public class ResourcePackDisplay extends Display {
 	
 	public ResourcePackDisplay() {
 		super(true, true,
-				new Menu.Builder(false, 2, RelPos.CENTER, getPacksAsEntries()).setSize(48, 64).createMenu());
+				new Menu.Builder(false, 2, RelPos.CENTER, getPacksAsEntries())
+				.setSize(48, 64)
+				.setPositioning(new Point(Screen.w/2, Screen.h*3/5), RelPos.CENTER)
+				.createMenu());
 
 		ListEntry[] ent = menus[0].getEntries();
 		for (int i = 0; i < ent.length; i++) {
@@ -74,7 +78,7 @@ public class ResourcePackDisplay extends Display {
 		super.render(screen);
 
 		// Title
-		Font.drawCentered(Localization.getLocalized("Resource Packs"), screen, Screen.h - 180, Color.WHITE);
+		Font.drawCentered(Localization.getLocalized("Resource Packs"), screen, Screen.h / 2 - 64, Color.WHITE);
 
 		// Info text at the bottom.
 		Font.drawCentered("Use "+ Game.input.getMapping("cursor-down") + " and " + Game.input.getMapping("cursor-up") + " to move.", screen, Screen.h - 17, Color.DARK_GRAY);
@@ -84,7 +88,7 @@ public class ResourcePackDisplay extends Display {
 		int h = 2;
 		int w = 15;
 		int xo = (Screen.w - w * 8) / 2;
-		int yo = 28;
+		int yo = Screen.h / 2 - 40;
 
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {

--- a/src/main/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/main/java/minicraft/screen/ResourcePackDisplay.java
@@ -78,7 +78,7 @@ public class ResourcePackDisplay extends Display {
 		super.render(screen);
 
 		// Title
-		Font.drawCentered(Localization.getLocalized("Resource Packs"), screen, Screen.h / 2 - 64, Color.WHITE);
+		Font.drawCentered(Localization.getLocalized("Resource Packs"), screen, (Screen.h / 2 - 64), Color.WHITE);
 
 		// Info text at the bottom.
 		Font.drawCentered("Use "+ Game.input.getMapping("cursor-down") + " and " + Game.input.getMapping("cursor-up") + " to move.", screen, Screen.h - 17, Color.DARK_GRAY);
@@ -88,7 +88,7 @@ public class ResourcePackDisplay extends Display {
 		int h = 2;
 		int w = 15;
 		int xo = (Screen.w - w * 8) / 2;
-		int yo = Screen.h / 2 - 40;
+		int yo = Screen.h / 2 - 44;
 
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {

--- a/src/main/java/minicraft/screen/SkinDisplay.java
+++ b/src/main/java/minicraft/screen/SkinDisplay.java
@@ -22,6 +22,7 @@ import minicraft.core.io.InputHandler;
 import minicraft.gfx.Color;
 import minicraft.gfx.Font;
 import minicraft.gfx.MobSprite;
+import minicraft.gfx.Point;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteSheet;
 import minicraft.saveload.Save;
@@ -80,7 +81,11 @@ public class SkinDisplay extends Display {
 
 	public SkinDisplay() {
 		super(true, true,
-				new Menu.Builder(false, 2, RelPos.CENTER, getSkinsAsEntries()).setSize(48, 64).createMenu());
+				new Menu.Builder(false, 2, RelPos.CENTER, getSkinsAsEntries())
+				.setSize(48, 64)
+				.setPositioning(new Point(Screen.w/2, Screen.h*3/5), RelPos.CENTER)
+				.createMenu()
+			);
 	}
 
 	@Override
@@ -194,12 +199,12 @@ public class SkinDisplay extends Display {
 		step++;
 
 		// Title.
-		Font.drawCentered(Localization.getLocalized("minicraft.display.skin"), screen, Screen.h - 180, Color.WHITE);
+		Font.drawCentered(Localization.getLocalized("minicraft.display.skin"), screen, (Screen.h / 2 - 64), Color.WHITE);
 
 		int h = 2;
 		int w = 2;
 		int xOffset = Screen.w / 2 - w * 4; // Put this in the center of the screen
-		int yOffset = 40;
+		int yOffset = Screen.h/ 2 - 40; // Player sprite Y position
 
 		int spriteIndex = (step / 40) % 8; // 9 = 8 Frames for sprite
 
@@ -214,7 +219,7 @@ public class SkinDisplay extends Display {
 
 		// Help text.
 		Font.drawCentered("Use "+ Game.input.getMapping("cursor-down") + " and " + Game.input.getMapping("cursor-up") + " to move.", screen, Screen.h - 17, Color.DARK_GRAY);
-		Font.drawCentered(Game.input.getMapping("SELECT") + " to select, and " + Game.input.getMapping("EXIT") + " to cancel." , screen, Screen.h - 9, Color.DARK_GRAY);
+		Font.drawCentered(Game.input.getMapping("SELECT") + " to select, " + Game.input.getMapping("EXIT") + " to cancel." , screen, Screen.h - 9, Color.DARK_GRAY);
 	}
 
 	public static int getSelectedSkinIndex() {

--- a/src/main/java/minicraft/screen/SkinDisplay.java
+++ b/src/main/java/minicraft/screen/SkinDisplay.java
@@ -219,7 +219,7 @@ public class SkinDisplay extends Display {
 
 		// Help text.
 		Font.drawCentered("Use "+ Game.input.getMapping("cursor-down") + " and " + Game.input.getMapping("cursor-up") + " to move.", screen, Screen.h - 17, Color.DARK_GRAY);
-		Font.drawCentered(Game.input.getMapping("SELECT") + " to select, " + Game.input.getMapping("EXIT") + " to cancel." , screen, Screen.h - 9, Color.DARK_GRAY);
+		Font.drawCentered(Game.input.getMapping("SELECT") + " to select, and " + Game.input.getMapping("EXIT") + " to cancel." , screen, Screen.h - 9, Color.DARK_GRAY);
 	}
 
 	public static int getSelectedSkinIndex() {

--- a/src/main/java/minicraft/screen/TitleDisplay.java
+++ b/src/main/java/minicraft/screen/TitleDisplay.java
@@ -29,12 +29,13 @@ public class TitleDisplay extends Display {
 	private int rand;
 	private int count = 0; // This and reverse are for the logo; they produce the fade-in/out effect.
 	private boolean reverse = false;
+	private int TitleY;
 	
 	public TitleDisplay() {
+			
 		super(true, false, new Menu.Builder(false, 2, RelPos.CENTER,
 			new StringEntry("Checking for updates...", Color.BLUE),
 			new BlankEntry(),
-
 			new SelectEntry("Play", () -> {
 				if (WorldSelectDisplay.getWorldNames().size() > 0)
 					Game.setDisplay(new Display(true, new Menu.Builder(false, 2, RelPos.CENTER,
@@ -44,6 +45,7 @@ public class TitleDisplay extends Display {
 				else Game.setDisplay(new WorldGenDisplay());
 			}),
 			new SelectEntry("Options", () -> Game.setDisplay(new OptionsMainMenuDisplay())),
+            new SelectEntry("minicraft.display.skin", () -> Game.setDisplay(new SkinDisplay())),
 			new SelectEntry("minicraft.display.achievement", () -> Game.setDisplay(new AchievementsDisplay())),
 			new SelectEntry("Help", () ->
 				Game.setDisplay(new Display(true, new Menu.Builder(false, 1, RelPos.CENTER,
@@ -56,7 +58,7 @@ public class TitleDisplay extends Display {
 			),
 			new SelectEntry("Quit", Game::quit)
 			)
-			.setPositioning(new Point(Screen.w/2, Screen.h*3/5), RelPos.CENTER)
+			.setPositioning(new Point(Screen.w/2, Screen.h*3/5 - 8), RelPos.CENTER)
 			.createMenu()
 		);
 	}
@@ -64,6 +66,13 @@ public class TitleDisplay extends Display {
 	@Override
 	public void init(Display parent) {
 		super.init(null); // The TitleScreen never has a parent.
+		
+		if (OptionsMainMenuDisplay.originalAspectRatio == "16x9") {
+			TitleY = Screen.h / 2 - 64;
+		} else {
+			TitleY = Screen.h / 2 - 58;
+		}
+		
 		Renderer.readyToRenderGameplay = false;
 
 		// Check version
@@ -115,7 +124,7 @@ public class TitleDisplay extends Display {
 		int h = 2; // Height of squares (on the spritesheet)
 		int w = 15; // Width of squares (on the spritesheet)
 		int xo = (Screen.w - w * 8) / 2; // X location of the title
-		int yo = Screen.h / 2 - 58; // Y location of the title
+		int yo = TitleY; // Y location of the title
 		
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
@@ -138,9 +147,12 @@ public class TitleDisplay extends Display {
 		/// This isn't as complicated as it looks. It just gets a color based off of count, which oscilates between 0 and 25.
 		int bcol = 5 - count / 5; // This number ends up being between 1 and 5, inclusive.
 		int splashColor = isblue ? Color.BLUE : isRed ? Color.RED : isGreen ? Color.GREEN : Color.get(1, bcol*51, bcol*51, bcol*25);
-
 		
-		Font.drawCentered(splashes[rand], screen, (Screen.h / 2) - 33, splashColor);
+		if (OptionsMainMenuDisplay.originalAspectRatio == "16x9") {
+			Font.drawCentered(splashes[rand], screen, (Screen.h / 2) - 44, splashColor);
+		} else {
+			Font.drawCentered(splashes[rand], screen, (Screen.h / 2) - 38, splashColor);
+		}
 		
 		Font.draw("Version " + Game.VERSION, screen, 1, 1, Color.get(1, 51));
 		

--- a/src/main/java/minicraft/screen/TitleDisplay.java
+++ b/src/main/java/minicraft/screen/TitleDisplay.java
@@ -44,7 +44,6 @@ public class TitleDisplay extends Display {
 				else Game.setDisplay(new WorldGenDisplay());
 			}),
 			new SelectEntry("Options", () -> Game.setDisplay(new OptionsMainMenuDisplay())),
-            new SelectEntry("minicraft.display.skin", () -> Game.setDisplay(new SkinDisplay())),
 			new SelectEntry("minicraft.display.achievement", () -> Game.setDisplay(new AchievementsDisplay())),
 			new SelectEntry("Help", () ->
 				Game.setDisplay(new Display(true, new Menu.Builder(false, 1, RelPos.CENTER,
@@ -116,7 +115,7 @@ public class TitleDisplay extends Display {
 		int h = 2; // Height of squares (on the spritesheet)
 		int w = 15; // Width of squares (on the spritesheet)
 		int xo = (Screen.w - w * 8) / 2; // X location of the title
-		int yo = 18; // Y location of the title
+		int yo = Screen.h / 2 - 58; // Y location of the title
 		
 		for (int y = 0; y < h; y++) {
 			for (int x = 0; x < w; x++) {
@@ -141,7 +140,7 @@ public class TitleDisplay extends Display {
 		int splashColor = isblue ? Color.BLUE : isRed ? Color.RED : isGreen ? Color.GREEN : Color.get(1, bcol*51, bcol*51, bcol*25);
 
 		
-		Font.drawCentered(splashes[rand], screen, 40, splashColor);
+		Font.drawCentered(splashes[rand], screen, (Screen.h / 2) - 33, splashColor);
 		
 		Font.draw("Version " + Game.VERSION, screen, 1, 1, Color.get(1, 51));
 		


### PR DESCRIPTION
- Menus and some GUI components now adjust to aspect ratio
- Moved the Skins Entry to the Options Menu to reduce the amount of space taken up by the Title display options
- Fixed Resource packs and Skins menu, now its components are positioned correctly
- Fixed inventory search tip position
- Fixed Book gui height
- Fixed a bug regarding level rendering on screen