### PR TITLE
Resolve texture pack loading and TNT Damaging problem

### DIFF
--- a/src/main/java/minicraft/entity/furniture/Tnt.java
+++ b/src/main/java/minicraft/entity/furniture/Tnt.java
@@ -25,14 +25,14 @@ public class Tnt extends Furniture implements ActionListener {
 	private static int FUSE_TIME = 90;
 	private static int BLAST_RADIUS = 32;
 	private static int BLAST_DAMAGE = 30;
-	
+
 	private int ftik = 0;
 	private boolean fuseLit = false;
 	private Timer explodeTimer;
 	private Level levelSave;
 
 	private final String[] explosionBlacklist = new String[]{ "hard rock", "obsidian wall", "stairs up", "stairs down" };
-	
+
 	/**
 	 * Creates a new tnt furniture.
 	 */
@@ -40,25 +40,25 @@ public class Tnt extends Furniture implements ActionListener {
 		super("Tnt", new Sprite(28, 26, 2, 2, 2), 3, 2);
 		fuseLit = false;
 		ftik = 0;
-		
+
 		explodeTimer = new Timer(300, this);
 	}
 
 	@Override
 	public void tick() {
 		super.tick();
-		
+
 		if (fuseLit) {
 			ftik++;
-			
+
 			if (ftik >= FUSE_TIME) {
 				// Blow up
 				List<Entity> entitiesInRange = level.getEntitiesInRect(new Rectangle(x, y, BLAST_RADIUS * 2, BLAST_RADIUS * 2, Rectangle.CENTER_DIMS));
-				
+
 				for (Entity e: entitiesInRange) {
 					 float dist = (float) Math.hypot(e.x - x, e.y - y);
 					 int dmg = (int) (BLAST_DAMAGE * (1 - (dist / BLAST_RADIUS))) + 1;
-					 if (e instanceof Mob)
+					 if (e instanceof Mob && dmg > 0)
 						((Mob)e).onExploded(this, dmg);
 
 					 // Ignite other bombs in range.
@@ -71,7 +71,7 @@ public class Tnt extends Furniture implements ActionListener {
 						 }
 					 }
 				}
-				
+
 				int xt = x >> 4;
 				int yt = (y - 2) >> 4;
 
@@ -88,14 +88,14 @@ public class Tnt extends Furniture implements ActionListener {
 				Sound.explode.play();
 
 				level.setAreaTiles(xt, yt, 1, Tiles.get("explode"), 0, explosionBlacklist);
-				
+
 				levelSave = level;
 				explodeTimer.start();
 				super.remove();
 			}
 		}
 	}
-	
+
 	@Override
 	public void render(Screen screen) {
 		if (fuseLit) {
@@ -104,7 +104,7 @@ public class Tnt extends Furniture implements ActionListener {
 		}
 		super.render(screen);
 	}
-	
+
 	/**
 	 * Does the explosion.
 	 */
@@ -121,7 +121,7 @@ public class Tnt extends Furniture implements ActionListener {
 
 		levelSave = null;
 	}
-	
+
 	@Override
 	public boolean interact(Player player, Item heldItem, Direction attackDir) {
 		if (!fuseLit) {
@@ -129,19 +129,19 @@ public class Tnt extends Furniture implements ActionListener {
 			Sound.fuse.play();
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	@Override
 	protected String getUpdateString() {
 		String updates = super.getUpdateString() + ";";
 		updates += "fuseLit," + fuseLit+
 		";ftik," + ftik;
-		
+
 		return updates;
 	}
-	
+
 	@Override
 	protected boolean updateField(String field, String val) {
 		if (super.updateField(field, val)) return true;
@@ -149,7 +149,7 @@ public class Tnt extends Furniture implements ActionListener {
 			case "fuseLit": fuseLit = Boolean.parseBoolean(val); return true;
 			case "ftik": ftik = Integer.parseInt(val); return true;
 		}
-		
+
 		return false;
 	}
 }

--- a/src/main/java/minicraft/entity/furniture/Tnt.java
+++ b/src/main/java/minicraft/entity/furniture/Tnt.java
@@ -24,7 +24,7 @@ import minicraft.screen.AchievementsDisplay;
 public class Tnt extends Furniture implements ActionListener {
 	private static int FUSE_TIME = 90;
 	private static int BLAST_RADIUS = 32;
-	private static int BLAST_DAMAGE = 30;
+	private static int BLAST_DAMAGE = 80;
 
 	private int ftik = 0;
 	private boolean fuseLit = false;

--- a/src/main/java/minicraft/entity/mob/Player.java
+++ b/src/main/java/minicraft/entity/mob/Player.java
@@ -55,26 +55,26 @@ import org.tinylog.Logger;
 
 public class Player extends Mob implements ItemHolder, ClientTickable {
 	protected InputHandler input;
-	
+
 	private static final int playerHurtTime = 30;
 	public static final int INTERACT_DIST = 12;
 	private static final int ATTACK_DIST = 20;
-	
+
 	private static final int mtm = 300; // Time given to increase multiplier before it goes back to 1.
 	public static final int MAX_MULTIPLIER = 50; // Maximum score multiplier.
-	
+
 	public double moveSpeed = 1; // The number of coordinate squares to move; each tile is 16x16.
 	private int score; // The player's score
-	
+
 	private int multipliertime = mtm; // Time left on the current multiplier.
 	private int multiplier = 1; // Score multiplier
-	
+
 	// These 2 ints are ints saved from the first spawn - this way the spawn pos is always saved.
 	public int spawnx = 0, spawny = 0; // These are stored as tile coordinates, not entity coordinates.
 	//public boolean bedSpawn = false;
 
 	public boolean suitOn;
-	
+
 	// The maximum stats that the player can have.
 	public static final int maxStat = 10;
 	public static final int maxHealth = maxStat, maxStamina = maxStat, maxHunger = maxStat;
@@ -86,25 +86,25 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	public static MobSprite[][] suitSprites;
 
 	private Inventory inventory;
-	
+
 	public Item activeItem;
 	Item attackItem; // attackItem is useful again b/c of the power glove.
 	private Item prevItem; // Holds the item held before using the POW glove.
-	
+
 	int attackTime;
 	public Direction attackDir;
-	
+
 	private int onStairDelay; // The delay before changing levels.
 	private int onFallDelay; // The delay before falling b/c we're on an InfiniteFallTile
-	
+
 	public int hunger, stamina, armor; // The current stats
 	public int armorDamageBuffer;
 	@Nullable public ArmorItem curArmor; // The color/type of armor to be displayed.
-	
+
 	private int staminaRecharge; // The ticks before charging a bolt of the player's stamina
 	private static final int maxStaminaRecharge = 10; // Cutoff value for staminaRecharge
 	public int staminaRechargeDelay; // The recharge delay ticks when the player uses up their stamina.
-	
+
 	private int hungerStamCnt, stamHungerTicks; // Tiers of hunger penalties before losing a burger.
 	private static final int maxHungerTicks = 400; // The cutoff value for stamHungerTicks
 	private static final int[] maxHungerStams = {10, 7, 5}; // TungerStamCnt required to lose a burger.
@@ -114,12 +114,12 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	private int stepCount; // Used to penalize hunger for movement.
 	private int hungerChargeDelay; // The delay between each time the hunger bar increases your health
 	private int hungerStarveDelay; // The delay between each time the hunger bar decreases your health
-	
+
 	public HashMap<PotionType, Integer> potioneffects; // The potion effects currently applied to the player
 	public boolean showpotioneffects; // Whether to display the current potion effects on screen
 	private int cooldowninfo; // Prevents you from toggling the info pane on and off super fast.
 	private int regentick; // Counts time between each time the regen potion effect heals you.
-	
+
 	//private final int acs = 25; // Default ("start") arrow count
 	public int shirtColor = Color.get(1, 51, 51, 0); // Player shirt color.
 
@@ -127,9 +127,9 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	public int maxFishingTicks = 120;
 	public int fishingTicks = maxFishingTicks;
 	public int fishingLevel;
-	
+
 	// Note: the player's health & max health are inherited from Mob.java
-	
+
 	public String getDebugHunger() { return hungerStamCnt+"_"+stamHungerTicks; }
 
 	public Player(@Nullable Player previousInstance, InputHandler input) {
@@ -139,7 +139,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		y = 24;
 		this.input = input;
 		inventory = new Inventory() {
-			
+
 			@Override
 			public void add(int idx, Item item) {
 				if (Game.isMode("creative")) {
@@ -150,7 +150,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				}
 				super.add(idx, item);
 			}
-			
+
 			@Override
 			public Item remove(int idx) {
 				if (Game.isMode("creative")) {
@@ -167,26 +167,26 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			}
 		};
 
-		
+
 		potioneffects = new HashMap<>();
 		showpotioneffects = true;
-		
+
 		cooldowninfo = 0;
 		regentick = 0;
-		
+
 		attackDir = dir;
 		armor = 0;
 		curArmor = null;
 		armorDamageBuffer = 0;
 		stamina = maxStamina;
 		hunger = maxHunger;
-		
+
 		hungerStamCnt = maxHungerStams[Settings.getIdx("diff")];
 		stamHungerTicks = maxHungerTicks;
-		
+
 		if (Game.isMode("creative"))
 			Items.fillCreativeInv(inventory);
-		
+
 		if (previousInstance != null) {
 			spawnx = previousInstance.spawnx;
 			spawny = previousInstance.spawny;
@@ -203,33 +203,33 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		suitSprites = selectedSkin[2];
 		carrySuitSprites = selectedSkin[3];
 	}
-	
+
 	public int getMultiplier() { return Game.isMode("score") ? multiplier : 1; }
-	
+
 	void resetMultiplier() {
 		multiplier = 1;
 		multipliertime = mtm;
 	}
-	
+
 	public void addMultiplier(int value) {
 		if (!Game.isMode("score")) return;
 		multiplier = Math.min(MAX_MULTIPLIER, multiplier+value);
 		multipliertime = Math.max(multipliertime, mtm - 5);
 	}
-	
+
 	public void tickMultiplier() {
 		if ((!Updater.paused) && multiplier > 1) {
 			if (multipliertime != 0) multipliertime--;
 			if (multipliertime <= 0) resetMultiplier();
 		}
 	}
-	
+
 	public int getScore() { return score; }
 	public void setScore(int score) { this.score = score; }
 	public void addScore(int points) {
 		score += points * getMultiplier();
 	}
-	
+
 	/**
 	 * Adds a new potion effect to the player.
 	 * @param type Type of potion.
@@ -238,7 +238,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	public void addPotionEffect(PotionType type, int duration) {
 		potioneffects.put(type, duration);
 	}
-	
+
 	/**
 	 * Adds a potion effect to the player.
 	 * @param type Type of effect.
@@ -246,22 +246,22 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	public void addPotionEffect(PotionType type) {
 		addPotionEffect(type, type.duration);
 	}
-	
+
 	/**
 	 * Returns all the potion effects currently affecting the player.
 	 * @return all potion effects on the player.
 	 */
 	public HashMap<PotionType, Integer> getPotionEffects() { return potioneffects; }
-	
+
 	@Override
 	public void tick() {
 		if (level == null || isRemoved()) return;
 		if (Game.getDisplay() != null) return; // Don't tick player when menu is open
-		
+
 		super.tick(); // Ticks Mob.java
 
 		tickMultiplier();
-		
+
 		if (potioneffects.size() > 0 && !Bed.inBed(this)) {
 			for (PotionType potionType: potioneffects.keySet().toArray(new PotionType[0])) {
 				if (potioneffects.get(potionType) <= 1) // If time is zero (going to be set to 0 in a moment)...
@@ -281,14 +281,14 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				fishingTicks = maxFishingTicks;
 			}
 		}
-		
+
 		if(cooldowninfo > 0) cooldowninfo--;
-		
+
 		if(input.getKey("potionEffects").clicked && cooldowninfo == 0) {
 			cooldowninfo = 10;
 			showpotioneffects = !showpotioneffects;
 		}
-		
+
 		Tile onTile = level.getTile(x >> 4, y >> 4); // Gets the current tile the player is on.
 		if (onTile == Tiles.get("Stairs Down") || onTile == Tiles.get("Stairs Up")) {
 			if (onStairDelay <= 0) { // When the delay time has passed...
@@ -296,7 +296,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				onStairDelay = 10; // Resets delay, since the level has now been changed.
 				return; // SKIPS the rest of the tick() method.
 			}
-			
+
 			onStairDelay = 10; // Resets the delay, if on a stairs tile, but the delay is greater than 0. In other words, this prevents you from ever activating a level change on a stair tile, UNTIL you get off the tile for 10+ ticks.
 		} else if (onStairDelay > 0) onStairDelay--; // Decrements stairDelay if it's > 0, but not on stair tile... does the player get removed from the tile beforehand, or something?
 
@@ -313,61 +313,61 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			stamina = maxStamina;
 			hunger = maxHunger;
 		}
-		
+
 		// Remember: staminaRechargeDelay is a penalty delay for when the player uses up all their stamina.
 		// staminaRecharge is the rate of stamina recharge, in some sort of unknown units.
 		if (stamina <= 0 && staminaRechargeDelay == 0 && staminaRecharge == 0) {
 			staminaRechargeDelay = 40; // Delay before resuming adding to stamina.
 		}
-		
+
 		if (staminaRechargeDelay > 0 && stamina < maxStamina) staminaRechargeDelay--;
-		
+
 		if (staminaRechargeDelay == 0) {
 			staminaRecharge++; // Ticks since last recharge, accounting for the time potion effect.
-			
+
 			if (isSwimming() && !potioneffects.containsKey(PotionType.Swim)) staminaRecharge = 0; // Don't recharge stamina while swimming.
-			
+
 			// Recharge a bolt for each multiple of maxStaminaRecharge.
 			while (staminaRecharge > maxStaminaRecharge) {
 				   staminaRecharge -= maxStaminaRecharge;
 				if (stamina < maxStamina) stamina++; // Recharge one stamina bolt per "charge".
 			}
 		}
-		
+
 		int diffIdx = Settings.getIdx("diff");
-		
+
 		if (hunger < 0) hunger = 0; // Error correction
-		
+
 		if (stamina < maxStamina) {
 			stamHungerTicks-=diffIdx; // Affect hunger if not at full stamina; this is 2 levels away from a hunger "burger".
 			if( stamina == 0) stamHungerTicks-=diffIdx; // Double effect if no stamina at all.
 		}
-		
+
 		// This if statement encapsulates the hunger system
 		if(!Bed.inBed(this)) {
 			if (hungerChargeDelay > 0) { // If the hunger is recharging health...
 				stamHungerTicks -= 2+diffIdx; // Penalize the hunger
 				if (hunger == 0) stamHungerTicks -= diffIdx; // Further penalty if at full hunger
 			}
-			
+
 			if (Updater.tickCount % Player.hungerTickCount[diffIdx] == 0)
 				stamHungerTicks--; // hunger due to time.
-			
+
 			if (stepCount >= Player.hungerStepCount[diffIdx]) {
 				stamHungerTicks--; // hunger due to exercise.
 				stepCount = 0; // reset.
 			}
-			
+
 			if (stamHungerTicks <= 0) {
 				stamHungerTicks += maxHungerTicks; // Reset stamHungerTicks
 				hungerStamCnt--; // Enter 1 level away from burger.
 			}
-			
+
 			while (hungerStamCnt <= 0) {
 				hunger--; // Reached burger level.
 				hungerStamCnt += maxHungerStams[diffIdx];
 			}
-			
+
 			/// System that heals you depending on your hunger
 			if (health < maxHealth && hunger > maxHunger/2) {
 				hungerChargeDelay++;
@@ -377,11 +377,11 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				}
 			}
 			else hungerChargeDelay = 0;
-			
+
 			if (hungerStarveDelay == 0) {
 				hungerStarveDelay = 120;
 			}
-			
+
 			if (hunger == 0 && health > minStarveHealth[diffIdx]) {
 				if (hungerStarveDelay > 0) hungerStarveDelay--;
 				if (hungerStarveDelay == 0) {
@@ -389,7 +389,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				}
 			}
 		}
-		
+
 		// regen health
 		if (potioneffects.containsKey(PotionType.Regen)) {
 			regentick++;
@@ -400,10 +400,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				}
 			}
 		}
-		
+
 		if (Updater.savecooldown > 0 && !Updater.saving)
 			Updater.savecooldown--;
-		
+
 
 		// Handle player input. Input is handled by the menu if we are in one.
 		if (Game.getDisplay() == null && !Bed.inBed(this)) {
@@ -417,7 +417,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				if (input.getKey("move-left").down) vec.x--;
 				if (input.getKey("move-right").down) vec.x++;
 			}
-			
+
 			// Executes if not saving; and... essentially halves speed if out of stamina.
 			if ((vec.x != 0 || vec.y != 0) && (staminaRechargeDelay % 2 == 0 || isSwimming()) && !Updater.saving) {
 				double spd = moveSpeed * (potioneffects.containsKey(PotionType.Speed) ? 1.5D : 1);
@@ -431,16 +431,16 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				boolean moved = move(xd, yd); // THIS is where the player moves; part of Mob.java
 				if (moved) stepCount++;
 			}
-			
-			
+
+
 			if (isSwimming() && tickTime % 60 == 0 && !potioneffects.containsKey(PotionType.Swim)) { // If drowning... :P
 				if (stamina > 0) payStamina(1); // Take away stamina
 				else directHurt(1, Direction.NONE); // If no stamina, take damage.
 			}
-			
+
 			if (activeItem != null && (input.getKey("drop-one").clicked || input.getKey("drop-stack").clicked)) {
 				Item drop = activeItem.clone();
-				
+
 				if (input.getKey("drop-one").clicked && drop instanceof StackableItem && ((StackableItem)drop).count > 1) {
 					// Drop one from stack
 					((StackableItem)activeItem).count--;
@@ -451,14 +451,14 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 
 				level.dropItem(x, y, drop);
 			}
-			
+
 			if ((activeItem == null || !activeItem.used_pending) && (input.getKey("attack").clicked) && stamina != 0 && onFallDelay <= 0) { // This only allows attacks when such action is possible.
 				if (!potioneffects.containsKey(PotionType.Energy)) stamina--;
 				staminaRecharge = 0;
 
 				attack();
 			}
-			
+
 			if (input.getKey("menu").clicked && activeItem != null) {
 				inventory.add(0, activeItem);
 				activeItem = null;
@@ -495,14 +495,14 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 					resolveHeldItem();
 				}
 			}
-			
+
 			if (attackTime > 0) {
 				attackTime--;
 				if(attackTime == 0) attackItem = null; // null the attackItem once we are done attacking.
 			}
 		}
 	}
-	
+
 	/**
 	 * Removes an held item and places it back into the inventory.
 	 * Looks complicated to so it can handle the powerglove.
@@ -542,10 +542,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			}
 			return;
 		}
-		
+
 		attackDir = dir; // Make the attack direction equal the current direction
 		attackItem = activeItem; // Make attackItem equal activeItem
-		
+
 		// If we are holding an item.
 		if (activeItem != null) {
 			attackTime = 10;
@@ -555,11 +555,11 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			if (activeItem instanceof ToolItem && stamina - 1 >= 0) {
 				ToolItem tool = (ToolItem) activeItem;
 				if (tool.type == ToolType.Bow && tool.dur > 0 && inventory.count(Items.arrowItem) > 0) {
-					
+
 					if (!Game.isMode("creative")) inventory.removeItem(Items.arrowItem);
 					level.add(new Arrow(this, attackDir, tool.level));
 					attackTime = 10;
-					
+
 					if (!Game.isMode("creative")) tool.dur--;
 
 					AchievementsDisplay.setAchievement("minicraft.achievement.bow",true);
@@ -570,7 +570,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 
 			// If the interaction between you and an entity is successful, then return.
 			if (interact(getInteractionBox(INTERACT_DIST))) return;
-			
+
 			// Attempt to interact with the tile.
 			Point t = getInteractionTile();
 
@@ -593,7 +593,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 						done = true;
 					}
 				}
-				
+
 				if (!Game.isMode("creative") && activeItem.isDepleted()) {
 					// If the activeItem has 0 items left, then "destroy" it.
 					activeItem = null;
@@ -601,12 +601,12 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			}
 			if (done) return; // Skip the rest if interaction was handled
 		}
-		
+
 		if (activeItem == null || activeItem.canAttack()) { // If there is no active item, OR if the item can be used to attack...
 			attackTime = 5;
 			// Attacks the enemy in the appropriate direction.
 			boolean used = hurt(getInteractionBox(ATTACK_DIST));
-			
+
 			// Attempts to hurt the tile in the appropriate direction.
 			Point t = getInteractionTile();
 
@@ -615,36 +615,36 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				Tile tile = level.getTile(t.x, t.y);
 				used = tile.hurt(level, t.x, t.y, this, random.nextInt(3) + 1, attackDir) || used;
 			}
-			
+
 			if (used && activeItem instanceof ToolItem)
 				((ToolItem)activeItem).payDurability();
 		}
 	}
-	
+
 	private Rectangle getInteractionBox(int range) {
 		int x = this.x, y = this.y - 2;
-		
+
 		//noinspection UnnecessaryLocalVariable
 		int paraClose = 4, paraFar = range;
 		int perpClose = 0, perpFar = 8;
-		
+
 		int xClose = x + dir.getX()*paraClose + dir.getY()*perpClose;
 		int yClose = y + dir.getY()*paraClose + dir.getX()*perpClose;
 		int xFar = x + dir.getX()*paraFar + dir.getY()*perpFar;
 		int yFar = y + dir.getY()*paraFar + dir.getX()*perpFar;
-		
+
 		return new Rectangle(Math.min(xClose, xFar), Math.min(yClose, yFar), Math.max(xClose, xFar), Math.max(yClose, yFar), Rectangle.CORNERS);
 	}
-	
+
 	private Point getInteractionTile() {
 		int x = this.x, y = this.y - 2;
-		
+
 		x += dir.getX()*INTERACT_DIST;
 		y += dir.getY()*INTERACT_DIST;
-		
+
 		return new Point(x >> 4, y >> 4);
 	}
-	
+
 	private void goFishing() {
 		int fcatch = random.nextInt(100);
 
@@ -664,11 +664,11 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 
 		if (data != null) { // If you've caught something
 			for (String line: data) {
-				
+
 				// Check all the entries in the data
 				// The number is a percent, if one fails, it moves down the list
 				// For entries with a "," it chooses between the options
-				
+
 				int chance = Integer.parseInt(line.split(":")[0]);
 				String itemData = line.split(":")[1];
 				if (random.nextInt(100) + 1 <= chance) {
@@ -699,9 +699,9 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		}
 		fishingTicks = maxFishingTicks; // If you didn't catch anything, try again in 120 ticks
 	}
-	
+
 	private boolean use() { return use(getInteractionBox(INTERACT_DIST)); }
-	
+
 	/** called by other use method; this serves as a buffer in case there is no entity in front of the player. */
 	private boolean use(Rectangle area) {
 		List<Entity> entities = level.getEntitiesInRect(area); // Gets the entities within the 4 points
@@ -710,7 +710,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		}
 		return false;
 	}
-	
+
 	/** same, but for interaction. */
 	private boolean interact(Rectangle area) {
 		List<Entity> entities = level.getEntitiesInRect(area);
@@ -719,7 +719,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		}
 		return false;
 	}
-	
+
 	/** same, but for attacking. */
 	private boolean hurt(Rectangle area) {
 		List<Entity> entities = level.getEntitiesInRect(area);
@@ -735,7 +735,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		}
 		return maxDmg > 0;
 	}
-	
+
 	/**
 	 * Calculates how much damage the player will do.
 	 * @param e Entity being attacked.
@@ -790,9 +790,9 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 					screen.render(xo + 0, yo + 3, 5 + 3 * 32, 0, 3);
 					screen.render(xo + 8, yo + 3, 5 + 3 * 32, 1, 3);
 			    }
-				
+
 			} else if (level.getTile(x / 16, y / 16) == Tiles.get("lava")) {
-				
+
 			    if (tickTime / 8 % 2 == 0) {
 					screen.render(xo + 0, yo + 3, 6 + 2 * 32, 1, 3); // Render the lava graphic
 					screen.render(xo + 8, yo + 3, 6 + 2 * 32, 0, 3); // Render the mirrored lava graphic to the right.
@@ -800,7 +800,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 					screen.render(xo + 0, yo + 3, 6 + 3 * 32, 1, 3);
 					screen.render(xo + 8, yo + 3, 6 + 3 * 32, 0, 3);
 			    }
-				
+
 			}
 		}
 
@@ -901,9 +901,9 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 
 	/** What happens when the player interacts with a itemEntity */
 	public void pickupItem(ItemEntity itemEntity) {
-		
+
 		Sound.pickup.play();
-		
+
 		itemEntity.remove();
 		addScore(1);
 		if (Game.isMode("creative")) return; // We shall not bother the inventory on creative mode.
@@ -969,7 +969,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	 * @param level The level.
 	 * @return true
 	 */
-    public void respawn(Level level) {        
+    public void respawn(Level level) {
         if (!level.getTile(spawnx, spawny).maySpawn())
         {
             findStartPos(level); // If there's no bed to spawn from, and the stored coordinates don't point to a grass tile, then find a new point.
@@ -984,7 +984,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
                     x += 4 * (x / -x);
                     y += 4 * (-y / y);
                 }
-                else 
+                else
                 {
                     spawnx = x ;
                     spawny = y ;

--- a/src/main/java/minicraft/item/FurnitureItem.java
+++ b/src/main/java/minicraft/item/FurnitureItem.java
@@ -17,6 +17,7 @@ import minicraft.entity.mob.AirWizard;
 import minicraft.entity.mob.Cow;
 import minicraft.entity.mob.Creeper;
 import minicraft.entity.mob.Knight;
+import minicraft.entity.mob.MobAi;
 import minicraft.entity.mob.Pig;
 import minicraft.entity.mob.Player;
 import minicraft.entity.mob.Sheep;
@@ -29,10 +30,10 @@ import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 
 public class FurnitureItem extends Item {
-	
+
 	protected static ArrayList<Item> getAllInstances() {
 		ArrayList<Item> items = new ArrayList<>();
-		
+
 		/// There should be a spawner for each level of mob, or at least make the level able to be changed.
 		items.add(new FurnitureItem(new Spawner(new Cow()), 1, 28));
 		items.add(new FurnitureItem(new Spawner(new Pig()), 2, 28));
@@ -44,10 +45,10 @@ public class FurnitureItem extends Item {
 		items.add(new FurnitureItem(new Spawner(new Snake(1)), 8, 28));
 		items.add(new FurnitureItem(new Spawner(new Knight(1)), 9, 28));
 		items.add(new FurnitureItem(new Spawner(new AirWizard(false)), 10, 28));
-		
+
 		items.add(new FurnitureItem(new Chest()));
 		items.add(new FurnitureItem(new DungeonChest(false, true)));
-		
+
 		// Add the various types of crafting furniture
 		for (Crafter.Type type: Crafter.Type.values()) {
 			 items.add(new FurnitureItem(new Crafter(type)));
@@ -56,29 +57,48 @@ public class FurnitureItem extends Item {
 		for (Lantern.Type type: Lantern.Type.values()) {
 			 items.add(new FurnitureItem(new Lantern(type)));
 		}
-		
+
 		items.add(new FurnitureItem(new Tnt()));
 		items.add(new FurnitureItem(new Bed()));
-		
+
 		return items;
 	}
-	
+
 	public Furniture furniture; // The furniture of this item
 	public boolean placed; // Value if the furniture has been placed or not.
 	private int sx, sy; // Sprite position
-	
+
 	private static int getSpritePos(int fpos) {
 		int x = fpos%32;
 		int y = fpos/32;
 		return ((x-8)/2) + y * 32;
 	}
-	
+
+	private static Sprite getFurnitureSprite(Furniture furniture) {
+		Sprite sprite;
+		if (furniture instanceof Spawner) {
+			MobAi mob = ((Spawner)furniture).mob;
+			if (mob instanceof Cow) sprite = new Sprite(1, 28, 1, 1, 0);
+			else if (mob instanceof Pig) sprite = new Sprite(2, 28, 1, 1, 0);
+			else if (mob instanceof Sheep) sprite = new Sprite(3, 28, 1, 1, 0);
+			else if (mob instanceof Slime) sprite = new Sprite(4, 28, 1, 1, 0);
+			else if (mob instanceof Zombie) sprite = new Sprite(5, 28, 1, 1, 0);
+			else if (mob instanceof Creeper) sprite = new Sprite(6, 28, 1, 1, 0);
+			else if (mob instanceof Skeleton) sprite = new Sprite(7, 28, 1, 1, 0);
+			else if (mob instanceof Snake) sprite = new Sprite(8, 28, 1, 1, 0);
+			else if (mob instanceof Knight) sprite = new Sprite(9, 28, 1, 1, 0);
+			else if (mob instanceof AirWizard) sprite = new Sprite(10, 28, 1, 1, 0);
+			else sprite = new Sprite(getSpritePos(furniture.sprite.getPos()), 0);
+		} else sprite = new Sprite(getSpritePos(furniture.sprite.getPos()), 0);
+		return sprite;
+	}
+
 	public FurnitureItem(Furniture furniture) {
-		super(furniture.name, new Sprite(getSpritePos(furniture.sprite.getPos()), 0));
+		super(furniture.name, getFurnitureSprite(furniture));
 		this.furniture = furniture; // Assigns the furniture to the item
 		placed = false;
 	}
-	
+
 	public FurnitureItem(Furniture furniture, int sx , int sy) {
 		super(furniture.name, new Sprite(sx, sy, 1, 1, 0)); // get the sprite directly
 		this.sx = sx;
@@ -86,12 +106,12 @@ public class FurnitureItem extends Item {
 		this.furniture = furniture;
 		placed = false;
 	}
-	
+
 	/** Determines if you can attack enemies with furniture (you can't) */
 	public boolean canAttack() {
 		return false;
 	}
-	
+
 	/** What happens when you press the "Attack" key with the furniture in your hands */
 	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
 		if (tile.mayPass(level, xt, yt, furniture)) { // If the furniture can go on the tile
@@ -100,22 +120,22 @@ public class FurnitureItem extends Item {
 			// Placed furniture's X and Y positions
 			furniture.x = xt * 16 + 8;
 			furniture.y = yt * 16 + 8;
-			
+
 			level.add(furniture); // Adds the furniture to the world
 			if (Game.isMode("creative"))
 				furniture = furniture.clone();
 			else
 				placed = true; // The value becomes true, which removes it from the player's active item
-			
+
 			return true;
 		}
 		return false;
 	}
-	
+
 	public boolean isDepleted() {
 		return placed;
 	}
-	
+
 	public FurnitureItem clone() {
 		// in case the item is a spawner, it will use the sprite position (sx, sy)
 		// instead if it is not, the constructor will obtain said sprite

--- a/src/main/java/minicraft/level/tile/ExplodedTile.java
+++ b/src/main/java/minicraft/level/tile/ExplodedTile.java
@@ -14,18 +14,19 @@ public class ExplodedTile extends Tile {
 			return !isSide || tile.connectsToLiquid();
 		}
 	};
-	
+
 	protected ExplodedTile(String name) {
 		super(name, sprite);
 		connectsToSand = true;
 		connectsToFluid = true;
 	}
-	
-	public void steppedOn(Level level, int x, int y, Entity entity) {
-		if (entity instanceof Mob)
-			((Mob)entity).hurt(this, x, y, 50);
-	}
-	
+
+	// What is the use of this code?
+	// public void steppedOn(Level level, int x, int y, Entity entity) {
+	// 	if (entity instanceof Mob)
+	// 		((Mob)entity).hurt(this, x, y, 50);
+	// }
+
 	public boolean mayPass(Level level, int x, int y, Entity e) {
 		return true;
 	}

--- a/src/main/java/minicraft/level/tile/ExplodedTile.java
+++ b/src/main/java/minicraft/level/tile/ExplodedTile.java
@@ -21,12 +21,6 @@ public class ExplodedTile extends Tile {
 		connectsToFluid = true;
 	}
 
-	// What is the use of this code?
-	// public void steppedOn(Level level, int x, int y, Entity entity) {
-	// 	if (entity instanceof Mob)
-	// 		((Mob)entity).hurt(this, x, y, 50);
-	// }
-
 	public boolean mayPass(Level level, int x, int y, Entity e) {
 		return true;
 	}

--- a/src/main/java/minicraft/screen/PlayerDeathDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerDeathDisplay.java
@@ -16,18 +16,18 @@ import minicraft.screen.entry.StringEntry;
 public class PlayerDeathDisplay extends Display {
 	// this is an IMPORTANT bool, determines if the user should respawn or not. :)
 	public static boolean shouldRespawn = true;
-	
+
 	public PlayerDeathDisplay() {
 		super(false, false);
-		
+
 		ArrayList<ListEntry> entries = new ArrayList<>();
 		entries.addAll(Arrays.asList(
 			new StringEntry("Time: " + InfoDisplay.getTimeString()),
 			new StringEntry("Score: " + Game.player.getScore()),
 			new BlankEntry()
 		));
-		
-		if(!Settings.get("mode").equals("hardcore")) {
+
+		if(!Settings.get("mode").toString().equalsIgnoreCase("hardcore")) {
 			entries.add(new SelectEntry("Respawn", () -> {
 				World.resetGame();
 				Game.setDisplay(null); //sets the menu to nothing
@@ -35,7 +35,7 @@ public class PlayerDeathDisplay extends Display {
 		}
 
 		entries.add(new SelectEntry("Quit", () -> Game.setDisplay(new TitleDisplay())));
-		
+
 		menus = new Menu[]{
 			new Menu.Builder(true, 0, RelPos.LEFT, entries)
 				.setPositioning(new Point(SpriteSheet.boxWidth, SpriteSheet.boxWidth * 3), RelPos.BOTTOM_RIGHT)
@@ -43,6 +43,6 @@ public class PlayerDeathDisplay extends Display {
 				.setTitlePos(RelPos.TOP_LEFT)
 				.createMenu()
 		};
-		
+
 	}
 }

--- a/src/main/java/minicraft/screen/PlayerDeathDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerDeathDisplay.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 
 import minicraft.core.Game;
 import minicraft.core.World;
-import minicraft.core.io.Settings;
 import minicraft.gfx.Point;
 import minicraft.gfx.SpriteSheet;
 import minicraft.saveload.Save;
@@ -33,7 +32,6 @@ public class PlayerDeathDisplay extends Display {
 				Game.setDisplay(null);
 			}));
 		}
-
 
 		entries.add(new SelectEntry("Save and Quit", () -> {
 			new Save(WorldSelectDisplay.getWorldName());

--- a/src/main/java/minicraft/screen/PlayerDeathDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerDeathDisplay.java
@@ -8,6 +8,7 @@ import minicraft.core.World;
 import minicraft.core.io.Settings;
 import minicraft.gfx.Point;
 import minicraft.gfx.SpriteSheet;
+import minicraft.saveload.Save;
 import minicraft.screen.entry.BlankEntry;
 import minicraft.screen.entry.ListEntry;
 import minicraft.screen.entry.SelectEntry;
@@ -33,6 +34,11 @@ public class PlayerDeathDisplay extends Display {
 			}));
 		}
 
+
+		entries.add(new SelectEntry("Save and Quit", () -> {
+			new Save(WorldSelectDisplay.getWorldName());
+			Game.setDisplay(new TitleDisplay());
+		}));
 		entries.add(new SelectEntry("Quit", () -> Game.setDisplay(new TitleDisplay())));
 
 		menus = new Menu[]{

--- a/src/main/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/main/java/minicraft/screen/ResourcePackDisplay.java
@@ -52,7 +52,7 @@ public class ResourcePackDisplay extends Display {
 
 		return resourceList;
 	}
-	
+
 	public ResourcePackDisplay() {
 		super(true, true,
 				new Menu.Builder(false, 2, RelPos.CENTER, getPacksAsEntries())
@@ -246,8 +246,8 @@ public class ResourcePackDisplay extends Display {
 			// Only allow two levels of folders.
 			if (path.length <= 2) {
 				// Check if entry is a folder. If it is, add it to the first map, if not, add it to the second map.
+				String[] validNames = { "textures", "localization", "sound" };
 				if (entry.isDirectory()) {
-					String[] validNames = { "textures", "localization", "sound" };
 					for (String name : validNames) {
 						if (path[0].equals(name)) {
 							resources.put(path[0], new HashMap<>());
@@ -258,7 +258,16 @@ public class ResourcePackDisplay extends Display {
 					if (path.length == 1) continue;
 
 					HashMap<String, ZipEntry> directory = resources.get(path[0]);
-					if (directory == null) continue;
+					if (directory == null) {
+						// If it is not exist, create it.
+						for (String name : validNames) {
+							if (path[0].equals(name)) {
+								resources.put(path[0], new HashMap<>());
+							}
+						}
+						directory = resources.get(path[0]);
+						if (directory == null) continue;
+					};
 
 					String[] validSuffixes = { ".json", ".wav", ".png" };
 					for (String suffix : validSuffixes) {


### PR DESCRIPTION
Resolve the texture pack loading problem.
Resolve the TNT damaging problem (damage mobs with negative damages) problem.
Resolve when the spawners are being picked up, the sprites always are shown with default sprite.
Ability to save the dead status.
Adjust TNT damage in order to cause damage with nearly 50 (with what was written in ExplodedTile#tick).