### PR TITLE
Fix world rename rendering

### DIFF
--- a/src/main/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/main/java/minicraft/screen/PlayerInvDisplay.java
@@ -40,6 +40,6 @@ public class PlayerInvDisplay extends Display {
 		// Searcher help text
 		String text = "(" + Game.input.getMapping("SEARCHER-BAR") + ") " + Localization.getLocalized("to search.");
 
-		Font.draw(text, screen, 12, Screen.h/ 2 + 16, Color.WHITE);
+		Font.draw(text, screen, 12, Screen.h/ 2 + 8, Color.WHITE);
 	}
 }

--- a/src/main/java/minicraft/screen/WorldEditDisplay.java
+++ b/src/main/java/minicraft/screen/WorldEditDisplay.java
@@ -177,7 +177,7 @@ public class WorldEditDisplay extends Display {
 			if(action == Action.Rename)
 				names.remove(worldName);
 			entries.add(new StringEntry("New World Name:", action.color));
-			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName));
+			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName, false));
 		}
 
 		entries.addAll(Arrays.asList(StringEntry.useLines(Color.WHITE, "",

--- a/src/main/java/minicraft/screen/WorldGenDisplay.java
+++ b/src/main/java/minicraft/screen/WorldGenDisplay.java
@@ -44,7 +44,7 @@ public class WorldGenDisplay extends Display {
 		}
 	}
 
-	public static InputEntry makeWorldNameInput(String prompt, List<String> takenNames, String initValue) {
+	public static InputEntry makeWorldNameInput(String prompt, List<String> takenNames, String initValue, boolean isGen) {
 		return new InputEntry(prompt, worldNameRegex, 36, initValue) {
 			@Override
 			public boolean isValid() {
@@ -64,7 +64,9 @@ public class WorldGenDisplay extends Display {
 
 			@Override
 			public void render(Screen screen, int x, int y, boolean isSelected) {
-				super.render(screen, getUserInput().length() > 11? x - (getUserInput().length()-11) * 8: x, y, isSelected);
+				super.render(screen, isGen?
+					(getUserInput().length() > 11? x - (getUserInput().length()-11) * 8: x):
+					x, y, isSelected);
 			}
 		};
 	}
@@ -72,7 +74,7 @@ public class WorldGenDisplay extends Display {
 	public WorldGenDisplay() {
 		super(true);
 
-		InputEntry nameField = makeWorldNameInput("Enter World Name", WorldSelectDisplay.getWorldNames(), "");
+		InputEntry nameField = makeWorldNameInput("Enter World Name", WorldSelectDisplay.getWorldNames(), "", true);
 
 		SelectEntry nameHelp = new SelectEntry("Trouble with world name?", () -> Game.setDisplay(new BookDisplay("it seems you've set letters as the controls to move the cursor up and down, which is probably annoying. This can be changed in the key binding menu as the \"cursor-XXX\" keys. For now, to type the letter instead of moving the cursor, hold the shift key while typing."))) {
 			@Override


### PR DESCRIPTION
This fixes the world renaming from rendering wrong position when over 11 characters.
Also fixes the inventory key hint with weird positioning. 