### PR TITLE
if --savedir is present, use it as final gameDir

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -16,7 +16,7 @@ Minicraft+ version 2.2.0
 * Changed a better logging
 * Fixed seed random problem
 * Improved the localization support
-* Changed how the game uses the --savedir command line argument. Now, when specified, the game will use it as the final game directory path instead of adding an extra '.playminicraft/mods/Minicraft_Plus' to it.
+* --savedir, if present, no longer is appended an extra '.playminicraft/mods/Minecraft Plus' to it
 
 Minicraft+ version 2.1.0
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -16,6 +16,7 @@ Minicraft+ version 2.2.0
 * Changed a better logging
 * Fixed seed random problem
 * Improved the localization support
+* Changed how the game uses the --savedir command line argument. Now, when specified, the game will use it as the final game directory path instead of adding an extra '.playminicraft/mods/Minicraft_Plus' to it.
 
 Minicraft+ version 2.1.0
 

--- a/src/main/java/minicraft/core/Initializer.java
+++ b/src/main/java/minicraft/core/Initializer.java
@@ -16,6 +16,7 @@ import minicraft.core.io.FileHandler;
 import minicraft.util.Logging;
 import minicraft.util.TinylogLoggingProvider;
 
+import org.jetbrains.annotations.Nullable;
 import org.tinylog.provider.ProviderRegistry;
 
 public class Initializer extends Game {
@@ -31,11 +32,12 @@ public class Initializer extends Game {
 
 	static void parseArgs(String[] args) {
 		// Parses command line arguments
-		String saveDir = FileHandler.getSystemGameDir();
+		@Nullable
+		String saveDir = null;
 		for (int i = 0; i < args.length; i++) {
 			if (args[i].equalsIgnoreCase("--debug")) {
 				debug = true;
-			} else if (args[i].equalsIgnoreCase("--savedir") && i+1 < args.length) {
+			} else if (args[i].equalsIgnoreCase("--savedir") && i + 1 < args.length) {
 				i++;
 				saveDir = args[i];
 			} else if (args[i].equalsIgnoreCase("--fullscreen")) {
@@ -54,8 +56,6 @@ public class Initializer extends Game {
 
 		FileHandler.determineGameDir(saveDir);
 	}
-
-
 
 	/** This is the main loop that runs the game. It:
 	 *	-keeps track of the amount of time that has passed

--- a/src/main/java/minicraft/core/io/FileHandler.java
+++ b/src/main/java/minicraft/core/io/FileHandler.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import org.jetbrains.annotations.Nullable;
+
 import minicraft.core.CrashHandler;
 import minicraft.core.Game;
 import minicraft.saveload.Save;
@@ -41,29 +43,39 @@ public class FileHandler extends Game {
 	}
 
 
-	public static void determineGameDir(String saveDir) {
-		gameDir = saveDir + localGameDir;
-		Logging.GAMEHANDLER.debug("Determined gameDir: " + gameDir);
+	public static void determineGameDir(@Nullable String saveDir) {
+		if (saveDir != null) {
+			gameDir = saveDir;
+			Logging.GAMEHANDLER.debug("Determined gameDir: " + gameDir);
 
-		File testFile = new File(gameDir);
-		testFile.mkdirs();
+			File gameDirFile = new File(gameDir);
+			gameDirFile.mkdirs();
+		} else {
+			saveDir = FileHandler.getSystemGameDir();
 
-		File oldFolder = new File(saveDir + "/.playminicraft/mods/Minicraft Plus");
-		if (oldFolder.exists()) {
-			try {
-				copyFolderContents(oldFolder.toPath(), testFile.toPath(), RENAME_COPY, true);
-			} catch (IOException e) {
-				CrashHandler.errorHandle(e);
-			}
-		}
+			gameDir = saveDir + localGameDir;
+			Logging.GAMEHANDLER.debug("Determined gameDir: " + gameDir);
 
-		if (OS.contains("mac")) {
-			oldFolder = new File(saveDir + "/.playminicraft");
+			File testFile = new File(gameDir);
+			testFile.mkdirs();
+
+			File oldFolder = new File(saveDir + "/.playminicraft/mods/Minicraft Plus");
 			if (oldFolder.exists()) {
 				try {
 					copyFolderContents(oldFolder.toPath(), testFile.toPath(), RENAME_COPY, true);
 				} catch (IOException e) {
 					CrashHandler.errorHandle(e);
+				}
+			}
+
+			if (OS.contains("mac")) {
+				oldFolder = new File(saveDir + "/.playminicraft");
+				if (oldFolder.exists()) {
+					try {
+						copyFolderContents(oldFolder.toPath(), testFile.toPath(), RENAME_COPY, true);
+					} catch (IOException e) {
+						CrashHandler.errorHandle(e);
+					}
 				}
 			}
 		}

--- a/src/main/java/minicraft/core/io/FileHandler.java
+++ b/src/main/java/minicraft/core/io/FileHandler.java
@@ -43,6 +43,14 @@ public class FileHandler extends Game {
 	}
 
 
+	/**
+	 * Determines the path the game will use to store worlds, settings, resource packs, etc.
+	 * If saveDir is not null, use it as the game directory. Otherwise use the default path.
+	 * <p>
+	 * If the default path is used, check if old default path exists and if so move it to the new path.
+	 *
+	 * @param saveDir Value from --savedir argument. Null if it was not set.
+	 */
 	public static void determineGameDir(@Nullable String saveDir) {
 		if (saveDir != null) {
 			gameDir = saveDir;

--- a/src/main/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/main/java/minicraft/screen/ResourcePackDisplay.java
@@ -31,7 +31,7 @@ public class ResourcePackDisplay extends Display {
 	private static final int SHEET_DIMENSIONS = 256;
 
 	private static final String DEFAULT_RESOURCE_PACK = "Default";
-	private static final File FOLDER_LOCATION = new File(FileHandler.getSystemGameDir() + "/" + FileHandler.getLocalGameDir() + "/resourcepacks");
+	private static final File FOLDER_LOCATION = new File(FileHandler.gameDir + "/resourcepacks");
 
 	private static String loadedPack = DEFAULT_RESOURCE_PACK;
 

--- a/src/main/java/minicraft/screen/SkinDisplay.java
+++ b/src/main/java/minicraft/screen/SkinDisplay.java
@@ -51,7 +51,7 @@ public class SkinDisplay extends Display {
 		defaultSkins = skinNames.size();
 
 		// Get the folder containing the skins.
-		File skinsFolder = new File(FileHandler.getSystemGameDir() + "/" + FileHandler.getLocalGameDir() + "/skins");
+		File skinsFolder = new File(FileHandler.gameDir + "/skins");
 
 		// Create folder, and see if it was successful.
 		if (skinsFolder.mkdirs()) {


### PR DESCRIPTION
Right now, when the --savedir is specified the game appends "/.playminicraft/mods/Minicraft Plus" to it. However, this should not be the case. If the user gives a path to use as the save dir then that should be the final path to use.