### PR TITLE
Add Logo Splash Screen before first render

### DIFF
--- a/src/main/java/minicraft/core/Renderer.java
+++ b/src/main/java/minicraft/core/Renderer.java
@@ -104,6 +104,7 @@ public class Renderer extends Game {
 		screen.pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
 		hudSheet = new LinkedSprite(SpriteType.Gui, "hud");
 
+		Initializer.startCanvasRendering();
 		canvas.createBufferStrategy(3);
 		canvas.requestFocus();
 	}


### PR DESCRIPTION
As the title described, this adds a logo splash screen other than the jar splash screen. It is because there are still moments the main game renderer has not started.