### PR TITLE
Fix lighting rendering

### DIFF
--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -463,6 +463,8 @@ public class Level {
 		int h = (Screen.h + 15) >> 4;
 
 		screen.setOffset(xScroll, yScroll);
+		
+		// this specifies the maximum radius that the game will stop rendering the light from the source object once off screen
 		int r = 4;
 
 		List<Entity> entities = getEntitiesInTiles(xo - r, yo - r, w + xo + r, h + yo + r);

--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -465,7 +465,7 @@ public class Level {
 		screen.setOffset(xScroll, yScroll);
 		
 		// this specifies the maximum radius that the game will stop rendering the light from the source object once off screen
-		int r = 4;
+		int r = 8;
 
 		List<Entity> entities = getEntitiesInTiles(xo - r, yo - r, w + xo + r, h + yo + r);
 		for (Entity e: entities) {


### PR DESCRIPTION
- Lanterns, specifically the gold one, have a larger light radius than the radius the game is able to render once the source object is off screen rendering.
- This should fix #253
   