### PR TITLE
Fix fishing data wrong path

### DIFF
--- a/src/main/java/minicraft/item/FishingData.java
+++ b/src/main/java/minicraft/item/FishingData.java
@@ -19,7 +19,7 @@ public class FishingData {
     public static List<String> getData(String name) {
         List<String> data;
         try {
-            data = Load.loadFile("/resources/fishing/" + name + "_loot.txt");
+            data = Load.loadFile("/resources/data/fishing/" + name + "_loot.txt");
         } catch (IOException e) {
             e.printStackTrace();
             data = new ArrayList<>();


### PR DESCRIPTION
### Context:
- When they made changes to the game's resource directory, they forgot to also update the path where the fishing system loot is obtained, causing the game to crash when trying to fish something