### PR TITLE
Making sheep and cow eating grasses

### DIFF
--- a/src/main/java/minicraft/entity/mob/Cow.java
+++ b/src/main/java/minicraft/entity/mob/Cow.java
@@ -3,6 +3,9 @@ package minicraft.entity.mob;
 import minicraft.core.io.Settings;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.item.Items;
+import minicraft.level.tile.GrassTile;
+import minicraft.level.tile.Tile;
+import minicraft.level.tile.Tiles;
 
 public class Cow extends PassiveMob {
 	private static LinkedSprite[][] sprites = Mob.compileMobSpriteAnimations(0, 0, "cow");
@@ -23,5 +26,17 @@ public class Cow extends PassiveMob {
 		dropItem(min, max, Items.get("leather"), Items.get("raw beef"));
 
 		super.die();
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+		if (random.nextInt(1000) == 0) { // Grazing without any benefits.
+			Tile tile = level.getTile(x >> 4, y >> 4);
+			// If tall grasses are present, these are consumed and then turn into grass tiles.
+			if (tile instanceof GrassTile) {
+				level.setTile(x >> 4, y >> 4, Tiles.get("dirt"));
+			}
+		}
 	}
 }

--- a/src/main/java/minicraft/entity/mob/Sheep.java
+++ b/src/main/java/minicraft/entity/mob/Sheep.java
@@ -18,10 +18,7 @@ public class Sheep extends PassiveMob {
 	private static final LinkedSprite[][] sprites = Mob.compileMobSpriteAnimations(0, 0, "sheep");
 	private static final LinkedSprite[][] cutSprites = Mob.compileMobSpriteAnimations(0, 2, "sheep");
 
-	private static final int WOOL_GROW_TIME = 3 * 60 * Updater.normSpeed; // Three minutes
-
 	public boolean cut = false;
-	private int ageWhenCut = 0;
 
 	/**
 	 * Creates a sheep entity.
@@ -65,7 +62,6 @@ public class Sheep extends PassiveMob {
 			if (((ToolItem) item).type == ToolType.Shears) {
 				cut = true;
 				dropItem(1, 3, Items.get("Wool"));
-				ageWhenCut = age;
 				((ToolItem) item).payDurability();
 				return true;
 			}

--- a/src/main/java/minicraft/entity/mob/Sheep.java
+++ b/src/main/java/minicraft/entity/mob/Sheep.java
@@ -1,7 +1,5 @@
 package minicraft.entity.mob;
 
-import org.jetbrains.annotations.Nullable;
-
 import minicraft.core.Updater;
 import minicraft.core.io.Settings;
 import minicraft.entity.Direction;
@@ -11,6 +9,10 @@ import minicraft.item.Item;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
+import minicraft.level.tile.GrassTile;
+import minicraft.level.tile.Tile;
+import minicraft.level.tile.Tiles;
+import org.jetbrains.annotations.Nullable;
 
 public class Sheep extends PassiveMob {
 	private static final LinkedSprite[][] sprites = Mob.compileMobSpriteAnimations(0, 0, "sheep");
@@ -46,7 +48,14 @@ public class Sheep extends PassiveMob {
 	@Override
 	public void tick() {
 		super.tick();
-		if (age - ageWhenCut > WOOL_GROW_TIME) cut = false;
+		if (random.nextInt(1000) == 0) { // Grazing
+			Tile tile = level.getTile(x >> 4, y >> 4);
+			// If tall grasses are present, these are consumed and then turn into grass tiles.
+			if (tile instanceof GrassTile) {
+				level.setTile(x >> 4, y >> 4, Tiles.get("dirt"));
+				cut = false;
+			}
+		}
 	}
 
 	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {

--- a/src/main/java/minicraft/entity/mob/Sheep.java
+++ b/src/main/java/minicraft/entity/mob/Sheep.java
@@ -45,10 +45,10 @@ public class Sheep extends PassiveMob {
 	@Override
 	public void tick() {
 		super.tick();
-		if (random.nextInt(1000) == 0) { // Grazing
-			Tile tile = level.getTile(x >> 4, y >> 4);
-			// If tall grasses are present, these are consumed and then turn into grass tiles.
-			if (tile instanceof GrassTile) {
+		Tile tile = level.getTile(x >> 4, y >> 4);
+		// If tall grasses are present, these are consumed and then turn into grass tiles.
+		if (tile instanceof GrassTile) {
+			if (random.nextInt(1000) == 0) { // Grazing
 				level.setTile(x >> 4, y >> 4, Tiles.get("dirt"));
 				cut = false;
 			}


### PR DESCRIPTION
Resolves #225
Sheep and cow now eat grass on the floor. (grazing)
Tile interaction is added instead of interacting with item entities because making passive mobs eating dropped food items on the ground does not make sense. First, the item entities disappear in very short time. Second, items are dropped *only when the player drops items manually*, so, the chance of making this happening is too small. Third, meeting passive mobs is already a rare thing. These factors are the points needed to be considered into account.