### PR TITLE
Clean up Level.java

### DIFF
--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
 public class Level {
 	private final Random random;
@@ -71,7 +72,12 @@ public class Level {
 	private final List<Entity> entitiesToRemove = new ArrayList<>(); /// entities that will be removed from the level on next tick are stored here. This is for the sake of multithreading optimization. (hopefully)
 
 	// Creates a sorter for all the entities to be rendered.
-	private static final Comparator<Entity> spriteSorter = Comparator.comparingInt(e -> e.y);
+	//private static Comparator<Entity> spriteSorter = Comparator.comparingInt(e -> e.y); // Broken
+	@SuppressWarnings("Convert2Lambda")
+	private static Comparator<Entity> spriteSorter = Comparator.comparingInt(new ToIntFunction<Entity>() {
+		@Override
+		public int applyAsInt(Entity e) { return e.y; }
+	});
 
 	public Entity[] getEntitiesToSave() {
 		Entity[] allEntities = new Entity[entities.size() + entitiesToAdd.size()];

--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -6,11 +6,24 @@ import minicraft.core.io.Localization;
 import minicraft.core.io.Settings;
 import minicraft.entity.Entity;
 import minicraft.entity.ItemEntity;
-import minicraft.entity.Spark;
 import minicraft.entity.furniture.Chest;
 import minicraft.entity.furniture.DungeonChest;
 import minicraft.entity.furniture.Spawner;
-import minicraft.entity.mob.*;
+import minicraft.entity.mob.AirWizard;
+import minicraft.entity.mob.Cow;
+import minicraft.entity.mob.Creeper;
+import minicraft.entity.mob.EnemyMob;
+import minicraft.entity.mob.Knight;
+import minicraft.entity.mob.Mob;
+import minicraft.entity.mob.MobAi;
+import minicraft.entity.mob.PassiveMob;
+import minicraft.entity.mob.Pig;
+import minicraft.entity.mob.Player;
+import minicraft.entity.mob.Sheep;
+import minicraft.entity.mob.Skeleton;
+import minicraft.entity.mob.Slime;
+import minicraft.entity.mob.Snake;
+import minicraft.entity.mob.Zombie;
 import minicraft.gfx.Point;
 import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
@@ -20,9 +33,15 @@ import minicraft.level.tile.Tiles;
 import minicraft.level.tile.TorchTile;
 import minicraft.util.Logging;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import java.util.function.Predicate;
-import java.util.function.ToIntFunction;
 
 public class Level {
 	private final Random random;
@@ -47,21 +66,16 @@ public class Level {
 
 	private final Object entityLock = new Object(); // I will be using this lock to avoid concurrency exceptions in entities and sparks set
 	private final Set<Entity> entities = java.util.Collections.synchronizedSet(new HashSet<>()); // A list of all the entities in the world
-	private final Set<Spark> sparks = java.util.Collections.synchronizedSet(new HashSet<>()); // A list of all the sparks in the world
 	private final Set<Player> players = java.util.Collections.synchronizedSet(new HashSet<>()); // A list of all the players in the world
 	private final List<Entity> entitiesToAdd = new ArrayList<>(); /// entities that will be added to the level on next tick are stored here. This is for the sake of multithreading optimization. (hopefully)
 	private final List<Entity> entitiesToRemove = new ArrayList<>(); /// entities that will be removed from the level on next tick are stored here. This is for the sake of multithreading optimization. (hopefully)
 
 	// Creates a sorter for all the entities to be rendered.
-	//private static Comparator<Entity> spriteSorter = Comparator.comparingInt(e -> e.y); // Broken
-	private static Comparator<Entity> spriteSorter = Comparator.comparingInt(new ToIntFunction<Entity>() {
-		@Override
-		public int applyAsInt(Entity e) { return e.y; }
-	});
+	private static final Comparator<Entity> spriteSorter = Comparator.comparingInt(e -> e.y);
 
 	public Entity[] getEntitiesToSave() {
-		Entity[] allEntities = new Entity[entities.size() + sparks.size() + entitiesToAdd.size()];
-		Entity[] toAdd = entitiesToAdd.toArray(new Entity[entitiesToAdd.size()]);
+		Entity[] allEntities = new Entity[entities.size() + entitiesToAdd.size()];
+		Entity[] toAdd = entitiesToAdd.toArray(new Entity[0]);
 		Entity[] current = getEntityArray();
 		System.arraycopy(current, 0, allEntities, 0, current.length);
 		System.arraycopy(toAdd, 0, allEntities, current.length, toAdd.length);
@@ -263,7 +277,7 @@ public class Level {
 							}
 						}
 					} else { // y axis
-						for (int s = y2; s < y2 - s; s++) {
+						for (int s = y2; s < h - s; s++) {
 							if (getTile(x2, s) == Tiles.get("Obsidian Wall") || getTile(x2, s) == Tiles.get("Ornate Obsidian")) {
 								d.x = x2 * 23 - 14;
 								d.y = s * 21 - 16;
@@ -311,13 +325,9 @@ public class Level {
 				if (Game.debug) printEntityStatus("Adding ", entity, "furniture.DungeonChest", "mob.AirWizard", "mob.Player");
 
 				synchronized (entityLock) {
-					if (entity instanceof Spark) {
-						sparks.add((Spark) entity);
-					} else {
-						entities.add(entity);
-						if (entity instanceof Player) {
-							players.add((Player) entity);
-						}
+					entities.add(entity);
+					if (entity instanceof Player) {
+						players.add((Player) entity);
 					}
 				}
 			}
@@ -339,9 +349,6 @@ public class Level {
 				tickEntity(e);
 				if (e instanceof Mob) count++;
 			}
-
-			// Spark loop
-			sparks.forEach(this::tickEntity);
 		}
 
 		while (count > maxMobCount) {
@@ -364,11 +371,7 @@ public class Level {
 
 			entity.remove(this); // This will safely fail if the entity's level doesn't match this one.
 			synchronized (entityLock) {
-				if (entity instanceof Spark) {
-					sparks.remove(entity);
-				} else {
-					entities.remove(entity);
-				}
+				entities.remove(entity);
 			}
 
 			if (entity instanceof Player)
@@ -463,7 +466,7 @@ public class Level {
 		int h = (Screen.h + 15) >> 4;
 
 		screen.setOffset(xScroll, yScroll);
-		
+
 		// this specifies the maximum radius that the game will stop rendering the light from the source object once off screen
 		int r = 8;
 
@@ -623,13 +626,9 @@ public class Level {
 		int index = 0;
 
 		synchronized (entityLock) {
-			entityArray = new Entity[entities.size() + sparks.size()];
-
+			entityArray = new Entity[entities.size()];
 			for (Entity entity : entities) {
 				entityArray[index++] = entity;
-			}
-			for (Spark spark : sparks) {
-				entityArray[index++] = spark;
 			}
 		}
 
@@ -735,7 +734,7 @@ public class Level {
 	}
 
 	public Player[] getPlayers() {
-		return players.toArray(new Player[players.size()]);
+		return players.toArray(new Player[0]);
 	}
 
 	public Player getClosestPlayer(int x, int y) {
@@ -766,7 +765,7 @@ public class Level {
 			for (int xp = x-rx; xp <= x+rx; xp++)
 				if (xp >= 0 && xp < w && yp >= 0 && yp < h)
 					local.add(new Point(xp, yp));
-		return local.toArray(new Point[local.size()]);
+		return local.toArray(new Point[0]);
 	}
 
 	public Tile[] getAreaTiles(int x, int y, int r) { return getAreaTiles(x, y, r, r); }
@@ -776,7 +775,7 @@ public class Level {
 		for (Point p: getAreaTilePositions(x, y, rx, ry))
 			local.add(getTile(p.x, p.y));
 
-		return local.toArray(new Tile[local.size()]);
+		return local.toArray(new Tile[0]);
 	}
 
 	public void setAreaTiles(int xt, int yt, int r, Tile tile, int data) { setAreaTiles(xt, yt, r, tile, data, false); }
@@ -860,7 +859,7 @@ public class Level {
 							}
 						}
 					} else {
-						for (int s2 = y3; s2 < y3 - s2; s2++) {
+						for (int s2 = y3; s2 < h - s2; s2++) {
 							if (getTile(x3, s2) == Tiles.get("rock")) {
 								sp.x = x3 * 16 - 24;
 								sp.y = s2 * 16 - 24;
@@ -932,7 +931,7 @@ public class Level {
 							}
 						}
 					} else {
-						for (int s2 = y3; s2 < y3 - s2; s2++) {
+						for (int s2 = y3; s2 < h - s2; s2++) {
 							if (getTile(x3, s2) == Tiles.get("Obsidian Wall")) {
 								sp.x = x3 * 16 - 24;
 								sp.y = s2 * 16 - 24;
@@ -1007,7 +1006,7 @@ public class Level {
 						// Make the village look ruined
 						if (overlay == 1) {
 							Structure.villageRuinedOverlay1.draw(this, x + xo, y + yo);
-						} else if (overlay == 2) {
+						} else { // overlay == 2
 							Structure.villageRuinedOverlay2.draw(this, x + xo, y + yo);
 						}
 


### PR DESCRIPTION
- Removes the redundant `Level#sparks` set for sparks as there are no difference if they are combined into `Level#entities` set.
- Fixes the potential problem about y-axis (part of coordinate setting) is not looped due to the always-false conditional expression in some furniture generation.
- Makes `#toArray()` function always use empty arrays.