### PR TITLE
Update despawn conditions

### DIFF
--- a/src/main/java/minicraft/entity/Entity.java
+++ b/src/main/java/minicraft/entity/Entity.java
@@ -202,6 +202,9 @@ public abstract class Entity implements Tickable {
 		return true; // the move was successful.
 	}
 
+	/** Checks if the entity is able to naturally be despawned in general conditions. Handles (despawns) if true. */
+	public void checkDespawn() {}
+
 	/** This exists as a way to signify that the entity has been removed through player action and/or world action; basically, it's actually gone, not just removed from a level because it's out of range or something. Calls to this method are used to, say, drop items. */
 	public void die() { remove(); }
 

--- a/src/main/java/minicraft/entity/mob/Mob.java
+++ b/src/main/java/minicraft/entity/mob/Mob.java
@@ -27,6 +27,7 @@ public abstract class Mob extends Entity {
 	int walkTime;
 	public int speed;
 	int tickTime = 0; // Incremented whenever tick() is called, is effectively the age in ticks
+	int noActionTime = 0;
 
 	/**
 	 * Default constructor for a mob.
@@ -50,6 +51,7 @@ public abstract class Mob extends Entity {
 		tickTime++; // Increment our tick counter
 
 		if (isRemoved()) return;
+		noActionTime++;
 
 		if (level != null && level.getTile(x >> 4, y >> 4) == Tiles.get("lava")) // If we are trying to swim in lava
 			hurt(Tiles.get("lava"), x, y, 4); // Inflict 4 damage to ourselves, sourced from the lava Tile, with the direction as the opposite of ours.
@@ -123,6 +125,38 @@ public abstract class Mob extends Entity {
 		}
 
 		return moved;
+	}
+
+	/** The mob immediately despawns if the distance of the closest player is greater than the return value of this. */
+	protected int getDespawnDistance() {
+		return 80;
+	}
+
+	/** The mob randomly despawns if the distance of the closest player is greater than the return value of this. */
+	protected int getNoDespawnDistance() {
+		return 40;
+	}
+
+	/** @see #checkDespawn() */
+	protected boolean removeWhenFarAway(double distance) {
+		return true;
+	}
+
+	@Override
+	public void checkDespawn() {
+		double player = level.distanceOfClosestPlayer(this);
+		if (player > getDespawnDistance() && removeWhenFarAway(player)) {
+			remove();
+			return;
+		}
+
+		int noDespawnDistance = getNoDespawnDistance();
+		// Randomly despawns if the time elapsed longer than 30 seconds farer than noDespawnDistance.
+		if (noActionTime > 1800 && this.random.nextInt(800) == 0 && player > noDespawnDistance && removeWhenFarAway(player)) {
+			remove();
+		} else if (player < noDespawnDistance) {
+			noActionTime = 0;
+		}
 	}
 
 	/** This is an easy way to make a list of sprites that are all part of the same "Sprite", so they have similar parameters, but they're just at different locations on the spreadsheet. */

--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -286,6 +286,7 @@ public class Level {
 	private void tickEntity(Entity entity) {
 		if (entity == null) return;
 
+		if (!entity.isRemoved()) entity.checkDespawn();
 		if (entity.isRemoved()) {
 			remove(entity);
 			return;
@@ -344,19 +345,6 @@ public class Level {
 			sparks.forEach(this::tickEntity);
 		}
 
-		while (count > maxMobCount) {
-			Entity removeThis = (Entity)entities.toArray()[(random.nextInt(entities.size()))];
-			if (removeThis instanceof MobAi) {
-				// Make sure there aren't any close players
-				boolean playerClose = entityNearPlayer(removeThis);
-
-				if (!playerClose) {
-					remove(removeThis);
-					count--;
-				}
-			}
-		}
-
 		while (entitiesToRemove.size() > 0) {
 			Entity entity = entitiesToRemove.get(0);
 
@@ -389,6 +377,16 @@ public class Level {
 			}
 		}
 		return false;
+	}
+
+	public double distanceOfClosestPlayer(Entity entity) {
+		double distance = Math.hypot(w, h);
+		for (Player player : players) {
+			double d = Math.hypot(Math.abs(entity.x - player.x), Math.abs(entity.y - player.y));
+			if (d < distance) distance = d;
+		}
+
+		return distance;
 	}
 
 	public void printEntityStatus(String entityMessage, Entity entity, String... searching) {
@@ -463,7 +461,7 @@ public class Level {
 		int h = (Screen.h + 15) >> 4;
 
 		screen.setOffset(xScroll, yScroll);
-		
+
 		// this specifies the maximum radius that the game will stop rendering the light from the source object once off screen
 		int r = 8;
 


### PR DESCRIPTION
- Updates the natural despawn conditions. (Old condition is totally replaced.)
  - Mobs farer than 40 tiles despawn randomly with 1/800 chance each tick after continuously 30 seconds away from players.
  - Mobs farer than 80 tiles despawn immediately.
- Updates the natural spawn conditions. (Old condition is totally replaced.)
  - Mobs randomly spawn at places between 10 and 40 tiles far from players. (30 trials for each player; distance check only available in 1 player at once.)
- Adds conditions to prevent despawning. (to-do; lack of ideas)