### PR TITLE
Resolve problems about the OSK Menu

### DIFF
--- a/src/main/java/minicraft/screen/CraftingDisplay.java
+++ b/src/main/java/minicraft/screen/CraftingDisplay.java
@@ -108,7 +108,8 @@ public class CraftingDisplay extends Display {
 	@Override
 	public void render(Screen screen) {
 		super.render(screen);
-		onScreenKeyboardMenu.render(screen);
+		if (onScreenKeyboardMenu != null)
+			onScreenKeyboardMenu.render(screen);
 	}
 
 	@Override

--- a/src/main/java/minicraft/screen/PopupDisplay.java
+++ b/src/main/java/minicraft/screen/PopupDisplay.java
@@ -3,6 +3,7 @@ package minicraft.screen;
 import com.studiohartman.jamepad.ControllerButton;
 import minicraft.core.Game;
 import minicraft.core.io.InputHandler;
+import minicraft.gfx.Screen;
 import minicraft.screen.entry.InputEntry;
 import minicraft.screen.entry.ListEntry;
 import minicraft.screen.entry.StringEntry;
@@ -46,6 +47,13 @@ public class PopupDisplay extends Display {
 	}
 
 	OnScreenKeyboardMenu onScreenKeyboardMenu;
+
+	@Override
+	public void render(Screen screen) {
+		super.render(screen);
+		if (onScreenKeyboardMenu != null)
+			onScreenKeyboardMenu.render(screen);
+	}
 
 	@Override
 	public void tick(InputHandler input) {

--- a/src/main/java/minicraft/screen/WorldGenDisplay.java
+++ b/src/main/java/minicraft/screen/WorldGenDisplay.java
@@ -206,6 +206,13 @@ public class WorldGenDisplay extends Display {
 	OnScreenKeyboardMenu onScreenKeyboardMenu;
 
 	@Override
+	public void render(Screen screen) {
+		super.render(screen);
+		if (onScreenKeyboardMenu != null)
+			onScreenKeyboardMenu.render(screen);
+	}
+
+	@Override
 	public void tick(InputHandler input) {
 		boolean acted = false; // Checks if typing action is needed to be handled.
 		boolean takeExitHandle = true;


### PR DESCRIPTION
Resolves a `NullPointerException` in `CraftingDisplay#render` method.
The `OnScreenKeyboardMenu` objects are now rendered on `PopupDisplay` and `WorldGenDisplay`.