### PR TITLE
Further resolves gradle run problem

### DIFF
--- a/src/main/java/minicraft/core/io/FileHandler.java
+++ b/src/main/java/minicraft/core/io/FileHandler.java
@@ -183,7 +183,8 @@ public class FileHandler extends Game {
 		ArrayList<String> names = new ArrayList<>();
 		try (Stream<Path> paths = Files.walk(path)) {
 			Path finalPath = path;
-			paths.forEach(p -> names.add(finalPath.getParent().relativize(p).toString()));
+			paths.forEach(p -> names.add(finalPath.getParent().relativize(p).toString().replace('\\', '/')+
+				(p.toFile().isDirectory() ? "/" : "")));
 			return names;
 		} catch (IOException e) {
 			throw new RuntimeException(e); // CRITICAL ERROR (GAME ASSETS)

--- a/src/main/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/main/java/minicraft/screen/ResourcePackDisplay.java
@@ -129,7 +129,7 @@ public class ResourcePackDisplay extends Display {
 					assets.add("pack.json");
 					assets.add("pack.png");
 					for (String name : assets) { // Copy only assets and pack configuration.
-						if (name.startsWith("assets/")) {
+						if (name.startsWith("assets/") || name.equals("pack.json") || name.equals("pack.png")) {
 							out.putNextEntry(new ZipEntry(name));
 							if (!name.endsWith("/")) {
 								int b;


### PR DESCRIPTION
As I test once more, it is found that the problem is not completely resolved. The problem in `FileHandler#listAssets()` is resolved by #421 previously, but the OS-dependent separator problem (zip files must use `/` as the separator but Windows uses `\` as the separator) and directory name conversion problem (directory paths do not directly convert into `String` with a tailing slash, and thus the path name is not recognized as a directory in zip file, which making unexpected files generated in temp zip files) exist. This fixes these problems and makes sure that `gradle run` can work properly.