### PR TITLE
Default FPS value

### DIFF
--- a/src/main/java/minicraft/core/io/Settings.java
+++ b/src/main/java/minicraft/core/io/Settings.java
@@ -137,6 +137,8 @@ public class Settings {
 
 		public FPSEntry(String label) {
 			super(label, false, getArray());
+			int rate = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate();
+			setValue(rate == DisplayMode.REFRESH_RATE_UNKNOWN ? 60 : rate % 10 == 0 ? rate : rate - rate % 10);
 		}
 
 		/**


### PR DESCRIPTION
After the change with FPS entry, the default value is always the first element, i.e. 10, which is not expected as a general default value. The default value is now determined by default monitor refresh rate. If the refresh rate is not a multiple of 10, it is subtracted until it is a multiple of 10. If the rate cannot be identified, 60 is used.