### PR TITLE
Obsidian Knight summon update

### DIFF
--- a/src/main/java/minicraft/item/SummonItem.java
+++ b/src/main/java/minicraft/item/SummonItem.java
@@ -65,7 +65,7 @@ public class SummonItem extends StackableItem {
 				// Check if we are on the right level and tile
 				if (level.depth == -4) {
 					// If the player nears the center.
-					if (new Rectangle(level.w/2-1, level.h/2-1, 3, 3).contains(player.x >> 4, player.y >> 4)) {
+					if (new Rectangle(level.w/2-3, level.h/2-3, 7, 7).contains(player.x >> 4, player.y >> 4)) {
 						if (!ObsidianKnight.active) {
 
 							// Pay stamina


### PR DESCRIPTION
As Obsidian Knight can only be summoned at the center of the boss room, the condition is updated. It should now be able to summon Obsidian Knight anywhere in the boss room.