### PR TITLE
Fix a crash returning item when fishing

### DIFF
--- a/src/main/java/minicraft/entity/mob/Player.java
+++ b/src/main/java/minicraft/entity/mob/Player.java
@@ -479,6 +479,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 					((StackableItem)drop).count = 1;
 				} else {
 					activeItem = null; // Remove it from the "inventory"
+					if (isFishing) {
+						isFishing = false;
+						fishingTicks = maxFishingTicks;
+					}
 				}
 
 				level.dropItem(x, y, drop);
@@ -498,13 +502,14 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 					if (stackable.count > 0) {
 						getLevel().dropItem(x, y, stackable.clone());
 					}
-
-					activeItem = null;
-				} else if (returned > 0) {
-					activeItem = null;
-				} else {
+				} else if (returned <= 0) {
 					getLevel().dropItem(x, y, activeItem);
-					activeItem = null;
+				}
+
+				activeItem = null;
+				if (isFishing) {
+					isFishing = false;
+					fishingTicks = maxFishingTicks;
 				}
 			}
 
@@ -533,6 +538,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				if (input.inputPressed("pickup") && (activeItem == null || !activeItem.used_pending)) {
 					if (!(activeItem instanceof PowerGloveItem)) { // If you are not already holding a power glove (aka in the middle of a separate interaction)...
 						prevItem = activeItem; // Then save the current item...
+						if (isFishing) {
+							isFishing = false;
+							fishingTicks = maxFishingTicks;
+						}
 						activeItem = new PowerGloveItem(); // and replace it with a power glove.
 					}
 					attack(); // Attack (with the power glove)


### PR DESCRIPTION
This fixes a bug that when a player is fishing and drop the item, open inventory menu or pick up a furniture, an error occurs. This is because the fishing state clean is done only when attacking again or the player is sleeping or swimming, but not for returning the item back to inventory and thus leading a `NullPointerException` for `activeItem` in rendering with `isFishing`.