### PR TITLE
Fixes loading bugs by obsidian knight update

### DIFF
--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -137,7 +137,7 @@ public class Load {
 				Logging.SAVELOAD.debug("Added DeathChest which contains exceed items.");
 			}
 
-			if (worldVer.compareTo(new Version("2.2.0-dev2")) < 0) {
+			if (worldVer.compareTo(new Version("2.2.0-dev3")) < 0) {
 				Logging.SAVELOAD.trace("Old version dungeon detected.");
 				ArrayList<ListEntry> entries = new ArrayList<>();
 				entries.addAll(Arrays.asList(StringEntry.useLines(Color.RED,

--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -729,7 +729,7 @@ public class Load {
 		player.spawnx = Integer.parseInt(data.remove(0));
 		player.spawny = Integer.parseInt(data.remove(0));
 		player.health = Integer.parseInt(data.remove(0));
-		if (worldVer.compareTo(new Version("2.2.0-dev2")) >= 0)
+		if (worldVer.compareTo(new Version("2.2.0-dev3")) >= 0)
 			player.extraHealth = Integer.parseInt(data.remove(0));
 		if (worldVer.compareTo(new Version("2.0.4-dev7")) >= 0)
 			player.hunger = Integer.parseInt(data.remove(0));


### PR DESCRIPTION
This problem is led by #403, containing unchecked problem that some of world loading versioning checks have used 2.2.0-dev2, which have already been released earlier. This is because the code was originally planned for dev2 but not for dev3. This may not be happening again due to confirmation of public release quality. Loading old world of a previous version should be checked as valid before releasing.

For players playing 2.2.0-dev3 and attempting to load old world of 2.2.0-dev2, two valid corresponding solutions in *solving* this problem are:
- The most problem-solving solution is modifying the world version saved in `Game.miniplussave`, into 2.2.0-dev1. This could let the game know that the world is old enough and there would not be further more problem in loading them as no more version conflicts exist between dev1 and dev2.
- The alternative solution is directly modifying the world save content, but this solution is not suggested, because the oldness of dungeon level is unable to be detected. Inserting a `0` after the 5th value separated by commas (`,`) saved in `Player.miniplussave` and the value would become the 6th value, the player would be able to load the world normally. As the dungeon is not regenerated, some potential problems with the unmatched boss may be led.