### PR TITLE
Fixes unknown item "Potion" unresolved

### DIFF
--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -853,6 +853,11 @@ public class Load {
 				name = name.replace("Shear", "Shears");
 		}
 
+		if (worldVer.compareTo(new Version("2.2.0-dev4")) < 0) {
+			if (name.startsWith("Potion"))
+				name = name.replace("Potion", "Awkward Potion");
+		}
+
 		return name;
 	}
 
@@ -952,7 +957,7 @@ public class Load {
 			}
 		}
 
-		Entity newEntity = null;
+		Entity newEntity;
 
 		if (entityName.equals("Spark") && !isLocalSave) {
 			int awID = Integer.parseInt(info.get(2));
@@ -965,10 +970,9 @@ public class Load {
 			}
 		} else {
 			int mobLvl = 1;
-			Class<?> c = null;
-			if (!Crafter.names.contains(entityName)) {
+			if (!Crafter.names.contains(entityName)) { // Entity missing debugging
 				try {
-					c = Class.forName("minicraft.entity.mob." + entityName);
+					Class.forName("minicraft.entity.mob." + entityName);
 				} catch (ClassNotFoundException ignored) {}
 			}
 

--- a/src/main/resources/resources/data/chestloot/dungeonchest.txt
+++ b/src/main/resources/resources/data/chestloot/dungeonchest.txt
@@ -8,7 +8,7 @@
 8,gem armor
 6,gold armor
 5,iron armor,2
-3,potion,10
+3,awkward potion,10
 4,speed potion,2
 6,speed potion,5
 3,light potion,2

--- a/src/main/resources/resources/data/chestloot/minidungeon.txt
+++ b/src/main/resources/resources/data/chestloot/minidungeon.txt
@@ -33,4 +33,4 @@
 12,cyan clothes
 12,purple clothes
 4,arrow,5
-:potion,1:coal,3:apple,3:dirt,7
+:awkward potion,1:coal,3:apple,3:dirt,7


### PR DESCRIPTION
As #423 replaced `Potion` item by `Awkward Potion`, there are unchecked problems that `Potion` items in old world are still being loaded without resolving them into `Awkward Potion` and thus resolving into instances of `UnknownItem`. Also, the chestloot tables are still using "potion" instead of "awkward potion", leading to the similar problem.