### PR TITLE
Fire sparks now collide with walls and disappear after a period stopped by walls

### DIFF
--- a/src/main/java/minicraft/entity/FireSpark.java
+++ b/src/main/java/minicraft/entity/FireSpark.java
@@ -10,10 +10,12 @@ import minicraft.gfx.SpriteLinker;
 public class FireSpark extends Entity {
 	private static final SpriteLinker.LinkedSprite sprite = new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Entity, "spark");
 
-	private int lifeTime; // How much time until the spark disappears
-	private double xa, ya; // The x and y acceleration
+	private final int lifeTime; // How much time until the spark disappears
+	private final double xa, ya; // The x and y acceleration
 	private double xx, yy; // The x and y positions
 	private int time; // The amount of time that has passed
+	private int stoppedTime;
+	private boolean stopped;
 	private final ObsidianKnight owner; // The Obsidian Knight that created this spark
 
 	/**
@@ -42,12 +44,27 @@ public class FireSpark extends Entity {
 			remove(); // Remove this from the world
 			return;
 		}
-		// Move the spark:
-		//if ()
-		xx += xa;
-		yy += ya;
-		x = (int) xx;
-		y = (int) yy;
+
+		if (stopped) {
+			stoppedTime++;
+			if (stoppedTime >= 50) { // Despawn if the spark has been stopped for 50 ticks.
+				remove();
+				return;
+			}
+		} else {
+			// Move the spark:
+			int x0 = (int) xx; // Original position
+			int y0 = (int) yy;
+			xx += xa; // Final position
+			yy += ya;
+			boolean stopped = true;
+			//noinspection RedundantIfStatement
+			if (move2(((int) xx) - x0, 0)) stopped = false; // This kind of difference is handled due to errors by flooring.
+			if (move2(0, ((int) yy) - y0)) stopped = false;
+			if (stopped) {
+				this.stopped = true;
+			}
+		}
 
 		Player player = getClosestPlayer();
 		if (player != null) { // Failsafe if player dies in a fire spark.


### PR DESCRIPTION
Originally, fire sparks pass through walls. but it seems that it would affect the feature of the boss room. The use of the boss room is to block all activities withinn the room interacting outside. Fire sparks also despawn after 50 ticks stopped by walls to prevent duplication and this may lightly increase the difficulty of the boss.