### PR TITLE
Fixed buffering problem on linux and os x

### DIFF
--- a/src/main/java/minicraft/core/Renderer.java
+++ b/src/main/java/minicraft/core/Renderer.java
@@ -108,14 +108,7 @@ public class Renderer extends Game {
 		hudSheet = new LinkedSprite(SpriteType.Gui, "hud");
 
 		Initializer.startCanvasRendering();
-		try { // Reference: https://stackoverflow.com/a/61843644.
-			canvas.createBufferStrategy(3, GraphicsEnvironment.getLocalGraphicsEnvironment()
-				.getDefaultScreenDevice()
-				.getDefaultConfiguration()
-				.getBufferCapabilities());
-		} catch (AWTException e) {
-			CrashHandler.crashHandle(e, new ErrorInfo("Canvas Initialization Failure", ErrorInfo.ErrorType.UNEXPECTED, true, "The canvas is unable to be initialized."));
-		}
+		canvas.createBufferStrategy(3);
 
 		canvas.requestFocus();
 	}

--- a/src/main/java/minicraft/core/io/Settings.java
+++ b/src/main/java/minicraft/core/io/Settings.java
@@ -5,6 +5,7 @@ import minicraft.screen.entry.ArrayEntry;
 import minicraft.screen.entry.BooleanEntry;
 
 import java.awt.DisplayMode;
+import java.awt.GraphicsEnvironment;
 import java.util.ArrayList;
 import java.util.HashMap;
 


### PR DESCRIPTION
It fixes the canvas initialization issues on Unix-like platforms. Works for me, on linux and should also work for [issue #465](https://github.com/MinicraftPlus/minicraft-plus-revived/issues/465).