### PR TITLE
Resolve dungeon regeneration blocking problem

### DIFF
--- a/src/main/java/minicraft/screen/LoadingDisplay.java
+++ b/src/main/java/minicraft/screen/LoadingDisplay.java
@@ -33,9 +33,8 @@ public class LoadingDisplay extends Display {
 			} catch (RuntimeException ex) {
 				Throwable t = ex.getCause();
 				if (t instanceof InterruptedException) {
-					Game.exitDisplay();
 					World.onWorldExits();
-					Game.exitDisplay();
+					Game.exitDisplay(); // Exits the loading display and returns to world select display.
 					Game.setDisplay(new PopupDisplay(null, "minicraft.displays.loading.regeneration_cancellation_popup.display"));
 				} else
 					throw ex;
@@ -46,6 +45,7 @@ public class LoadingDisplay extends Display {
 
 	@Override
 	public void init(Display parent) {
+		if (parent != null && parent.getParent() == this) return; // Undefined behaviour
 		super.init(parent);
 		percentage = 0;
 		progressType = "minicraft.displays.loading.message.world";

--- a/src/main/java/minicraft/screen/LoadingDisplay.java
+++ b/src/main/java/minicraft/screen/LoadingDisplay.java
@@ -26,7 +26,7 @@ public class LoadingDisplay extends Display {
 
 	public LoadingDisplay() {
 		super(true, false);
-		t = new Timer(500, e -> {
+		t = new Timer(500, e -> new Thread(() -> { // A new thread is required as this blocks the running thread.
 			try {
 				World.initWorld();
 				Game.setDisplay(null);
@@ -40,7 +40,7 @@ public class LoadingDisplay extends Display {
 				} else
 					throw ex;
 			}
-		});
+		}, "World Initialization Thread").start());
 		t.setRepeats(false);
 	}
 


### PR DESCRIPTION
This problem causing dungeon regeneration blocking an AWT thread is caused by a commit https://github.com/MinicraftPlus/minicraft-plus-revived/commit/053a4d940bde8d7bc4a64a52cf212646de882feb. This is done by mistake, so this adds back the thread use as this blocks the thread even in a timer thread.
When exiting the regeneration, it originally exits 3 times, but it is expected to exit only twice. This problem is resolved.
There is a problem with the parent display resolving which causes the loading display initializing the second time when exiting the regeneration causing undefined behaviour. The temporary resolution is to stop initializing the second time within the loading display.