### PR TITLE
Removes redundant lines by the revert

### DIFF
--- a/src/main/java/minicraft/core/io/Settings.java
+++ b/src/main/java/minicraft/core/io/Settings.java
@@ -34,9 +34,6 @@ public final class Settings {
 		options.put("quests", new BooleanEntry("Quests", false));
 		options.put("showquests", new BooleanEntry("Quests Panel", true));
 
-		options.put("language", new ArrayEntry<>("minicraft.settings.language", true, false, Localization.getLocales()));
-		options.get("language").setValue(Localization.getSelectedLanguage());
-
 		options.get("mode").setChangeAction(value ->
 			options.get("scoretime").setVisible("minicraft.settings.mode.score".equals(value))
 		);


### PR DESCRIPTION
https://github.com/MinicraftPlus/minicraft-plus-revived/commit/9de1e2a200cec588d80e21d9a2bd4b3df976104d reverted an unrelated change apart from the FPS setting change, which is the language setting entry, which had already been replaced by a separated display before.