### PR TITLE
Fixes world generation display name input entry rendering problem

### DIFF
--- a/src/main/java/minicraft/screen/Menu.java
+++ b/src/main/java/minicraft/screen/Menu.java
@@ -343,7 +343,10 @@ public class Menu {
 			ListEntry entry = entries.get(idx);
 
 			if(!(entry instanceof BlankEntry)) {
-				Point pos = entryPos.positionRect(new Dimension(entry.getWidth(), ListEntry.getHeight()), new Rectangle(entryBounds.getLeft(), y, entryBounds.getWidth(), ListEntry.getHeight(), Rectangle.CORNER_DIMS));
+				Point displacement = entry.getRenderingDisplacement();
+				Point pos = entryPos.positionRect(new Dimension(entry.getWidth(), ListEntry.getHeight()),
+					(displacement != null) ? new Rectangle(entryBounds.getLeft() + displacement.x, y + displacement.y, entryBounds.getWidth(), ListEntry.getHeight(), Rectangle.CORNER_DIMS) :
+						new Rectangle(entryBounds.getLeft(), y, entryBounds.getWidth(), ListEntry.getHeight(), Rectangle.CORNER_DIMS));
 				boolean selected = idx == selection;
 				if (searcherBarActive && useSearcherBar) {
 					entry.render(screen, pos.x, pos.y, selected, typingSearcher, Color.YELLOW);

--- a/src/main/java/minicraft/screen/WorldSelectDisplay.java
+++ b/src/main/java/minicraft/screen/WorldSelectDisplay.java
@@ -22,9 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.FutureTask;
 
 public class WorldSelectDisplay extends Display {
 
@@ -87,7 +84,7 @@ public class WorldSelectDisplay extends Display {
 			ArrayList<ListEntry> entries = new ArrayList<>();
 			ArrayList<String> names = WorldSelectDisplay.getWorldNames();
 			entries.add(new StringEntry("minicraft.displays.world_select.popups.display.change", Color.BLUE));
-			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName, false));
+			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName));
 			entries.addAll(Arrays.asList(StringEntry.useLines(Color.WHITE, "",
 				Localization.getLocalized("minicraft.displays.world_select.popups.display.confirm", Game.input.getMapping("select")),
 				Localization.getLocalized("minicraft.displays.world_select.popups.display.cancel", Game.input.getMapping("exit"))
@@ -135,7 +132,7 @@ public class WorldSelectDisplay extends Display {
 			ArrayList<String> names = WorldSelectDisplay.getWorldNames();
 			names.remove(worldName);
 			entries.add(new StringEntry("minicraft.displays.world_select.popups.display.change", Color.GREEN));
-			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName, false));
+			entries.add(WorldGenDisplay.makeWorldNameInput("", names, worldName));
 			entries.addAll(Arrays.asList(StringEntry.useLines(Color.WHITE, "",
 				Localization.getLocalized("minicraft.displays.world_select.popups.display.confirm", Game.input.getMapping("select")),
 				Localization.getLocalized("minicraft.displays.world_select.popups.display.cancel", Game.input.getMapping("exit"))

--- a/src/main/java/minicraft/screen/entry/ListEntry.java
+++ b/src/main/java/minicraft/screen/entry/ListEntry.java
@@ -3,7 +3,10 @@ package minicraft.screen.entry;
 import minicraft.core.io.InputHandler;
 import minicraft.gfx.Color;
 import minicraft.gfx.Font;
+import minicraft.gfx.Point;
 import minicraft.gfx.Screen;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -75,6 +78,14 @@ public abstract class ListEntry {
 	 */
 	public static int getHeight() {
 		return Font.textHeight();
+	}
+
+	/**
+	 * Calculates the rendering displacement of the entry in the menu.
+	 * @return a 2D point denoting the x and y displacement respectively.
+	 */
+	public @Nullable Point getRenderingDisplacement() {
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #486.
The original input entry renders unwisely, which means the entry is rendered with weird displacement, it is unable to check out the texts on the left when the string is longer than the width, also, the position of the entry to displace is not set ideally, it is intended to render precisely but it is not. So, this modifies these behaviours. It is now rendered correctly, and the right arrow on the left also moves according to the displacement of the entry. Also, it is now able to move the entry inspection to the left or to the right by using left and right keys respectively. When changes applied to the entry, the position resets.