### PR TITLE
Update splash screen coloring

### DIFF
--- a/src/main/java/minicraft/core/Initializer.java
+++ b/src/main/java/minicraft/core/Initializer.java
@@ -188,7 +188,7 @@ public class Initializer extends Game {
 		public Thread renderer = new Thread(() -> {
 			long lastTick = System.nanoTime();
 			do {
-				if (System.nanoTime() - lastTick >= 1E7) { // 10ms/tick
+				if (System.nanoTime() - lastTick >= 6E6) { // 6ms/tick
 					repaint();
 					lastTick = System.nanoTime();
 				}
@@ -202,40 +202,14 @@ public class Initializer extends Game {
 			super.paintComponent(g);
 			final int w = g.getClipBounds().width;
 			final int h = g.getClipBounds().height;
-
-			// Drawing background
-			// Drawing gradient border with width 100
-			Graphics2D g2d = (Graphics2D) g;
-			g2d.setPaint(new GradientPaint(100, 100, Color.WHITE, 0, 100, Color.GREEN)); // Left
-			g2d.fillRect(0, 100, 100, h - 200);
-			g2d.setPaint(new GradientPaint(w - 100, 100, Color.WHITE, w, 100, Color.GREEN)); // Right
-			g2d.fillRect(w - 100, 100, 100, h - 200);
-			g2d.setPaint(new GradientPaint(100, 100, Color.WHITE, 100, 0, Color.GREEN)); // Top
-			g2d.fillRect(100, 0, w - 200, 100);
-			g2d.setPaint(new GradientPaint(100, h - 100, Color.WHITE, 100, h, Color.GREEN)); // Bottom
-			g2d.fillRect(100, h - 100, w - 200, 100);
-			float[] fractions = new float[] { 0.0f, 1.0f };
-			Color[] colors = new Color[] { Color.WHITE, Color.GREEN };
-			g2d.setPaint(new RadialGradientPaint(new Rectangle(0, 0, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Top Left
-			g2d.fillRect(0, 0, 100, 100);
-			g2d.setPaint(new RadialGradientPaint(new Rectangle(w - 200, 0, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Top Right
-			g2d.fillRect(w - 100, 0, 100, 100);
-			g2d.setPaint(new RadialGradientPaint(new Rectangle(0, h - 200, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Bottom Left
-			g2d.fillRect(0, h - 100, 100, 100);
-			g2d.setPaint(new RadialGradientPaint(new Rectangle(w - 200, h - 200, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Bottom Right
-			g2d.fillRect(w - 100, h - 100, 100, 100);
-			// Drawing center white area
-			g.setColor(Color.WHITE);
-			g.fillRect(100, 100, w - 200, h - 200);
-
-			// Green Border Fading effect
-			g.setColor(new Color(255, 255, 255, Math.max(Math.min(255 - (int) (Math.pow(Math.cos(transparency/255.0 * Math.PI/2), 2) * 255), 255), 0)));
+			// Draw background
+			g.setColor(Color.BLACK);
 			g.fillRect(0, 0, w, h);
 
 			// Drawing the centered logo
 			if (transparency < 255) g.drawImage(logo, w/2 - logo.getWidth(frame)*2, h/2 - logo.getHeight(frame)*2, logo.getWidth(frame)*4, logo.getHeight(frame)*4, frame);
 
-			// Overall Fading effect
+			// Fading effect
 			g.setColor(new Color(0, 0, 0, Math.max(Math.min(255 - (int) (Math.cos(transparency/255.0 * Math.PI/2) * 255), 255), 0)));
 			g.fillRect(0, 0, w, h);
 
@@ -254,7 +228,8 @@ public class Initializer extends Game {
 		}
 
 		public  void setDisplay(boolean display) {
-			while (inAnimation || this.display && ticksElapsed <= 80) {} // Waiting for animation to finish for at least 80 ticks, i.e., 800ms.
+			//noinspection StatementWithEmptyBody
+			while (inAnimation || this.display && ticksElapsed <= 30) {} // Waiting for animation to finish for at least 30 ticks, i.e., 180ms.
 			this.display = display;
 			inAnimation = true;
 		}

--- a/src/main/java/minicraft/core/Initializer.java
+++ b/src/main/java/minicraft/core/Initializer.java
@@ -16,10 +16,14 @@ import javax.swing.WindowConstants;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.LinearGradientPaint;
+import java.awt.MultipleGradientPaint;
+import java.awt.RadialGradientPaint;
+import java.awt.Rectangle;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
@@ -27,6 +31,7 @@ import java.awt.event.WindowListener;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class Initializer extends Game {
 	private Initializer() {}
@@ -164,7 +169,7 @@ public class Initializer extends Game {
 	}
 
 	private static class LogoSplashCanvas extends JPanel {
-		private Image logo;
+		private final Image logo;
 
 		{
 			try {
@@ -175,13 +180,18 @@ public class Initializer extends Game {
 		}
 
 		private int transparency = 255;
-		private boolean display = false;
-		private boolean inAnimation = false;
-		private boolean interruptWhenAnimated = false;
+		private volatile boolean display = false;
+		private volatile boolean inAnimation = false;
+		private volatile boolean interruptWhenAnimated = false;
 
 		public Thread renderer = new Thread(() -> {
+			long lastTick = System.nanoTime();
 			do {
-				repaint();
+				if (System.nanoTime() - lastTick >= 1E7) { // 10ms/tick
+					repaint();
+					lastTick = System.nanoTime();
+				}
+
 				if (interruptWhenAnimated && !inAnimation) break;
 			} while (!Initializer.logoSplash.renderer.isInterrupted());
 		}, "Logo Splash Screen Renderer");
@@ -192,27 +202,40 @@ public class Initializer extends Game {
 			final int w = g.getClipBounds().width;
 			final int h = g.getClipBounds().height;
 
-			// Drawing colorful background.
+			// Drawing background
+			// Drawing gradient border with width 100
 			Graphics2D g2d = (Graphics2D) g;
-			int n = 6;
-			float[] fractions = new float[n];
-			Color[] colors = new Color[n];
-			for (int x = 0; x < n; x++) {
-				double sin = Math.sin(Math.PI * (255-transparency)/255.0);
-				double cos = Math.cos(Math.PI * x/n);
-				double hue = Math.abs((sin*210 + cos*45) % 360) / 360;
-				double s = 1 - Math.pow(Math.min(Math.sin(Math.cos(Math.abs(sin - cos))), 1), 4);
-				fractions[x] = (float) Math.sin((double) x/n * Math.PI/2) * x/n;
-				colors[x] = Color.getHSBColor((float) hue, (float) s, 1);
-			}
-			g2d.setPaint(new LinearGradientPaint(0, 0, w, 0, fractions, colors));
-			g2d.fillRect(0, 0, w, h);
+			g2d.setPaint(new GradientPaint(100, 100, Color.WHITE, 0, 100, Color.GREEN)); // Left
+			g2d.fillRect(0, 100, 100, h - 200);
+			g2d.setPaint(new GradientPaint(w - 100, 100, Color.WHITE, w, 100, Color.GREEN)); // Right
+			g2d.fillRect(w - 100, 100, 100, h - 200);
+			g2d.setPaint(new GradientPaint(100, 100, Color.WHITE, 100, 0, Color.GREEN)); // Top
+			g2d.fillRect(100, 0, w - 200, 100);
+			g2d.setPaint(new GradientPaint(100, h - 100, Color.WHITE, 100, h, Color.GREEN)); // Bottom
+			g2d.fillRect(100, h - 100, w - 200, 100);
+			float[] fractions = new float[] { 0.0f, 1.0f };
+			Color[] colors = new Color[] { Color.WHITE, Color.GREEN };
+			g2d.setPaint(new RadialGradientPaint(new Rectangle(0, 0, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Top Left
+			g2d.fillRect(0, 0, 100, 100);
+			g2d.setPaint(new RadialGradientPaint(new Rectangle(w - 200, 0, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Top Right
+			g2d.fillRect(w - 100, 0, 100, 100);
+			g2d.setPaint(new RadialGradientPaint(new Rectangle(0, h - 200, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Bottom Left
+			g2d.fillRect(0, h - 100, 100, 100);
+			g2d.setPaint(new RadialGradientPaint(new Rectangle(w - 200, h - 200, 200, 200), fractions, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE)); // Bottom Right
+			g2d.fillRect(w - 100, h - 100, 100, 100);
+			// Drawing center white area
+			g.setColor(Color.WHITE);
+			g.fillRect(100, 100, w - 200, h - 200);
 
-			// Drawing the centered logo.
+			// Green Border Fading effect
+			g.setColor(new Color(255, 255, 255, Math.max(Math.min(255 - (int) (Math.pow(Math.cos(transparency/255.0 * Math.PI/2), 2) * 255), 255), 0)));
+			g.fillRect(0, 0, w, h);
+
+			// Drawing the centered logo
 			if (transparency < 255) g.drawImage(logo, w/2 - logo.getWidth(frame)*2, h/2 - logo.getHeight(frame)*2, logo.getWidth(frame)*4, logo.getHeight(frame)*4, frame);
 
-			// Fading effect.
-			g.setColor(new Color(0, 0, 0, Math.max(Math.min(255 - (int) (Math.cos(transparency/255.0 * Math.PI) * 255), 255), 0)));
+			// Overall Fading effect
+			g.setColor(new Color(0, 0, 0, Math.max(Math.min(255 - (int) (Math.cos(transparency/255.0 * Math.PI/2) * 255), 255), 0)));
 			g.fillRect(0, 0, w, h);
 
 			if (inAnimation) {
@@ -226,7 +249,8 @@ public class Initializer extends Game {
 			}
 		}
 
-		public void setDisplay(boolean display) {
+		public  void setDisplay(boolean display) {
+			while (inAnimation) {} // Waiting for animation to finish.
 			this.display = display;
 			inAnimation = true;
 		}

--- a/src/main/java/minicraft/core/Initializer.java
+++ b/src/main/java/minicraft/core/Initializer.java
@@ -183,6 +183,7 @@ public class Initializer extends Game {
 		private volatile boolean display = false;
 		private volatile boolean inAnimation = false;
 		private volatile boolean interruptWhenAnimated = false;
+		private volatile int ticksElapsed = 0; // Ticks elapsed after faded in
 
 		public Thread renderer = new Thread(() -> {
 			long lastTick = System.nanoTime();
@@ -246,11 +247,14 @@ public class Initializer extends Game {
 					if (transparency < 255) transparency += 5;
 					else inAnimation = false;
 				}
+			} else if (display) {
+				//noinspection NonAtomicOperationOnVolatileField
+				ticksElapsed++;
 			}
 		}
 
 		public  void setDisplay(boolean display) {
-			while (inAnimation) {} // Waiting for animation to finish.
+			while (inAnimation || this.display && ticksElapsed <= 80) {} // Waiting for animation to finish for at least 80 ticks, i.e., 800ms.
 			this.display = display;
 			inAnimation = true;
 		}


### PR DESCRIPTION
First, there is only black background used in the current splash screen. Second, the speed of the fading is now constant and not depending on the looping speed. Also, the fading calculation problem on the alpha channel is now fixed, so it would now fade as expected. The faded in screen now holds at least 180ms before fading out even if background execution is finished. The whole fading process: fading in (306ms) -> holding (at 180ms least until background process finishes) -> fading out (360ms).