### PR TITLE
Fix problems caused by a revert in FPS entry change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 
-project.version = '2.2.0-dev3'
+project.version = '2.2.0-dev4'
 group = "java.minicraft"
 archivesBaseName = "minicraft-plus"
 

--- a/src/main/java/minicraft/core/io/Settings.java
+++ b/src/main/java/minicraft/core/io/Settings.java
@@ -12,7 +12,7 @@ public final class Settings {
 	private static final HashMap<String, ArrayEntry<?>> options = new HashMap<>();
 
 	static {
-		options.put("fps", new RangeEntry("minicraft.settings.fps", 10, 300, getDefaultRefreshRate())); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
+		options.put("fps", new RangeEntry("minicraft.settings.fps", 10, 300, getDefaultRefreshRate(), 10)); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
 		options.put("screenshot", new ArrayEntry<>("minicraft.settings.screenshot_scale", 1, 2, 5, 10, 15, 20)); // The magnification of screenshot. I would want to see ultimate sized.
 		options.put("diff", new ArrayEntry<>("minicraft.settings.difficulty", "minicraft.settings.difficulty.easy", "minicraft.settings.difficulty.normal", "minicraft.settings.difficulty.hard"));
 		options.get("diff").setSelection(1);
@@ -79,20 +79,25 @@ public final class Settings {
 	}
 
 	/**
-	 * Gets the refresh rate of the default monitor.
+	 * Gets the double of the refresh rate of the default monitor and rounds down the value to the nearest 10.
 	 * Safely handles headless environments (if that were to happen for some reason).
-	 * @return The refresh rate if successful. 60 if not.
+	 * @return The refresh rate if successful. 120 if not. 120 (double) is more optimal than 60.
 	 */
-	private static int getDefaultRefreshRate() {
+	public static int getDefaultRefreshRate() {
 		int hz;
 		try {
-			hz = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate();
+			hz = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate()
+				* 2; // Double the refresh rate as the max FPS value, which could make the rendering optimal without unstable tearing.
 		} catch (HeadlessException e) {
-			return 60;
+			return 120;
 		}
 
-		if (hz == DisplayMode.REFRESH_RATE_UNKNOWN) return 60;
-		if (hz > 300 || 10 >= hz) return 60;
-		return hz;
+		if (hz == DisplayMode.REFRESH_RATE_UNKNOWN) return 120;
+		if (hz > 300) {
+			return 300;
+		} else if (10 >= hz) {
+			return 10;
+		}
+		return hz % 10 == 0 ? hz : hz - hz % 10;
 	}
 }

--- a/src/main/java/minicraft/saveload/Load.java
+++ b/src/main/java/minicraft/saveload/Load.java
@@ -60,6 +60,7 @@ import minicraft.screen.ResourcePackDisplay;
 import minicraft.screen.SkinDisplay;
 import minicraft.screen.TutorialDisplayHandler;
 import minicraft.screen.entry.ListEntry;
+import minicraft.screen.entry.RangeEntry;
 import minicraft.screen.entry.StringEntry;
 import minicraft.util.AdvancementElement;
 import minicraft.util.Logging;
@@ -517,7 +518,18 @@ public class Load {
 		// Settings
 		Settings.set("sound", json.getBoolean("sound"));
 		Settings.set("autosave", json.getBoolean("autosave"));
-		Settings.set("fps", json.getInt("fps"));
+		if (prefVer.compareTo(new Version("2.2.0-dev3")) == 0) { // Setting exists only in 2.2.0-dev3
+			String fps = json.getString("fps");
+			if (fps.equals("Unlimited")) {
+				Settings.set("fps", ((RangeEntry) Settings.getEntry("fps")).max);
+			} else if (fps.equals("VSync")) {
+				Settings.set("fps", Settings.getDefaultRefreshRate());
+			} else {
+				Settings.set("fps", Integer.parseInt(fps));
+			}
+		} else {
+			Settings.set("fps", json.getInt("fps"));
+		}
 		Settings.set("showquests", json.optBoolean("showquests", true));
 
 		if (json.has("lang")) {

--- a/src/main/java/minicraft/screen/entry/RangeEntry.java
+++ b/src/main/java/minicraft/screen/entry/RangeEntry.java
@@ -1,31 +1,34 @@
 package minicraft.screen.entry;
 
 public class RangeEntry extends ArrayEntry<Integer> {
-	
-	private static Integer[] getIntegerArray(int min, int max) {
-		Integer[] ints = new Integer[max - min + 1];
-		
+
+	private static Integer[] getIntegerArray(int min, int max, int interval) {
+		Integer[] ints = new Integer[(max - min) / interval + 1];
+
 		for (int i = 0; i < ints.length; i++)
-			ints[i] = min+i;
-		
+			ints[i] = min + i*interval;
+
 		return ints;
 	}
-	
-	private int min, max;
-	
-	public RangeEntry(String label, int min, int max, int initial) {
-		super(label, false, getIntegerArray(min, max));
-		
+
+	public final int min, max;
+	private final int interval;
+
+	public RangeEntry(String label, int min, int max, int initial) { this(label, min, max, initial, 1); }
+	public RangeEntry(String label, int min, int max, int initial, int interval) {
+		super(label, false, getIntegerArray(min, max, interval));
+
 		this.min = min;
 		this.max = max;
-		
+		this.interval = interval;
+
 		setValue(initial);
 	}
-	
+
 	@Override
 	public void setValue(Object o) {
 		if (!(o instanceof Integer)) return;
-		
-		setSelection(((Integer)o)-min);
+
+		setSelection((((Integer)o)-min) / interval);
 	}
 }


### PR DESCRIPTION
A change in FPS entry made by #425 has been reverted by https://github.com/MinicraftPlus/minicraft-plus-revived/commit/9de1e2a200cec588d80e21d9a2bd4b3df976104d, but the change has already been proposed in 2.2.0-dev3, which may cause potential compatibility problem, so this fixes this problem, also redoes a change by #457 and a change from interval of 1 to 10 in FPS setting values.