### PR TITLE
Remove logo splash screen

### DIFF
--- a/src/client/java/minicraft/core/Game.java
+++ b/src/client/java/minicraft/core/Game.java
@@ -4,6 +4,7 @@ import minicraft.core.io.InputHandler;
 import minicraft.core.io.Settings;
 import minicraft.core.io.Sound;
 import minicraft.entity.mob.Player;
+import minicraft.gfx.Screen;
 import minicraft.level.Level;
 import minicraft.level.tile.Tiles;
 import minicraft.network.Analytics;
@@ -110,6 +111,7 @@ public class Game {
 			Updater.updateFullscreen();
 		}
 
+		Initializer.launchWindow();
 		// Actually start the game.
 		Initializer.run();
 

--- a/src/client/java/minicraft/core/Initializer.java
+++ b/src/client/java/minicraft/core/Initializer.java
@@ -9,22 +9,16 @@ import org.tinylog.provider.ProviderRegistry;
 
 import javax.imageio.ImageIO;
 import javax.swing.JFrame;
-import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.LinearGradientPaint;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Objects;
 
 public class Initializer extends Game {
 	private Initializer() {}
@@ -33,7 +27,6 @@ public class Initializer extends Game {
 	 * Reference to actual frame, also it may be null.
 	 */
 	static JFrame frame;
-	static LogoSplashCanvas logoSplash = new LogoSplashCanvas();
 	static int fra, tik; // These store the number of frames and ticks in the previous second; used for fps, at least.
 
 	public static JFrame getFrame() { return frame; }
@@ -120,12 +113,10 @@ public class Initializer extends Game {
 		Renderer.canvas.setMinimumSize(new java.awt.Dimension(1, 1));
 		Renderer.canvas.setPreferredSize(Renderer.getWindowSize());
 		Renderer.canvas.setBackground(Color.BLACK);
-		logoSplash.setMinimumSize(new java.awt.Dimension(1, 1));
-		logoSplash.setPreferredSize(Renderer.getWindowSize());
 		JFrame frame = Initializer.frame = new JFrame(NAME);
 		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		frame.setLayout(new BorderLayout()); // Sets the layout of the window
-		frame.add(logoSplash, BorderLayout.CENTER);
+		frame.add(Renderer.canvas, BorderLayout.CENTER); // Adds the game (which is a canvas) to the center of the screen.
 		frame.pack(); // Squishes everything into the preferredSize.
 
 		try {
@@ -157,94 +148,13 @@ public class Initializer extends Game {
 				quit();
 			}
 		});
+	}
 
+	/** Launching the main window. */
+	static void launchWindow() {
 		frame.setVisible(true);
-		logoSplash.setDisplay(true);
-		logoSplash.renderer.start();
-	}
-
-	private static class LogoSplashCanvas extends JPanel {
-		private Image logo;
-
-		{
-			try {
-				logo = ImageIO.read(Objects.requireNonNull(Initializer.class.getResourceAsStream("/assets/textures/gui/title.png")));
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		private int transparency = 255;
-		private boolean display = false;
-		private boolean inAnimation = false;
-		private boolean interruptWhenAnimated = false;
-
-		public Thread renderer = new Thread(() -> {
-			do {
-				repaint();
-				if (interruptWhenAnimated && !inAnimation) break;
-			} while (!Initializer.logoSplash.renderer.isInterrupted());
-		}, "Logo Splash Screen Renderer");
-
-		@Override
-		public void paintComponent(Graphics g) {
-			super.paintComponent(g);
-			final int w = g.getClipBounds().width;
-			final int h = g.getClipBounds().height;
-
-			// Drawing colorful background.
-			Graphics2D g2d = (Graphics2D) g;
-			int n = 6;
-			float[] fractions = new float[n];
-			Color[] colors = new Color[n];
-			for (int x = 0; x < n; x++) {
-				double sin = Math.sin(Math.PI * (255-transparency)/255.0);
-				double cos = Math.cos(Math.PI * x/n);
-				double hue = Math.abs((sin*210 + cos*45) % 360) / 360;
-				double s = 1 - Math.pow(Math.min(Math.sin(Math.cos(Math.abs(sin - cos))), 1), 4);
-				fractions[x] = (float) Math.sin((double) x/n * Math.PI/2) * x/n;
-				colors[x] = Color.getHSBColor((float) hue, (float) s, 1);
-			}
-			g2d.setPaint(new LinearGradientPaint(0, 0, w, 0, fractions, colors));
-			g2d.fillRect(0, 0, w, h);
-
-			// Drawing the centered logo.
-			if (transparency < 255) g.drawImage(logo, w/2 - logo.getWidth(frame)*2, h/2 - logo.getHeight(frame)*2, logo.getWidth(frame)*4, logo.getHeight(frame)*4, frame);
-
-			// Fading effect.
-			g.setColor(new Color(0, 0, 0, Math.max(Math.min(255 - (int) (Math.cos(transparency/255.0 * Math.PI) * 255), 255), 0)));
-			g.fillRect(0, 0, w, h);
-
-			if (inAnimation) {
-				if (display) {
-					if (transparency > 0) transparency -= 5;
-					else inAnimation = false;
-				} else {
-					if (transparency < 255) transparency += 5;
-					else inAnimation = false;
-				}
-			}
-		}
-
-		public void setDisplay(boolean display) {
-			this.display = display;
-			inAnimation = true;
-		}
-	}
-
-	/** Remove the logo splash screen and start canvas rendering. */
-	static void startCanvasRendering() {
-		logoSplash.setDisplay(false);
-		logoSplash.interruptWhenAnimated = true;
-		try {
-			logoSplash.renderer.join();
-		} catch (InterruptedException ignored) {}
-		logoSplash.renderer.interrupt();
-		frame.remove(logoSplash);
-		frame.add(Renderer.canvas, BorderLayout.CENTER); // Adds the game (which is a canvas) to the center of the screen.
-		frame.pack();
-		frame.revalidate();
-		logoSplash = null; // Discard the canvas.
+		frame.requestFocus();
+		Renderer.canvas.requestFocus();
 	}
 
 	/**

--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -104,10 +104,7 @@ public class Renderer extends Game {
 		screen.pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
 		hudSheet = new LinkedSprite(SpriteType.Gui, "hud");
 
-		Initializer.startCanvasRendering();
 		canvas.createBufferStrategy(3);
-
-		canvas.requestFocus();
 	}
 
 


### PR DESCRIPTION
After #495, the logo splash screen is completely removed by the request by @Makkkkus. Also, the window is now launched when canvas is ready to render. In a most ideal case, the window should be launched once the first render has been made.