### PR TITLE
Make FPS setting having an interval of 10 in values

### DIFF
--- a/src/client/java/minicraft/core/io/Settings.java
+++ b/src/client/java/minicraft/core/io/Settings.java
@@ -14,7 +14,7 @@ public final class Settings {
 	private static final HashMap<String, ArrayEntry<?>> options = new HashMap<>();
 
 	static {
-		options.put("fps", new RangeEntry("minicraft.settings.fps", 10, 300, getDefaultRefreshRate())); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
+		options.put("fps", new RangeEntry("minicraft.settings.fps", 10, 300, getDefaultRefreshRate(), 10)); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
 		options.put("screenshot", new ArrayEntry<>("minicraft.settings.screenshot_scale", 1, 2, 5, 10, 15, 20)); // The magnification of screenshot. I would want to see ultimate sized.
 		options.put("diff", new ArrayEntry<>("minicraft.settings.difficulty", "minicraft.settings.difficulty.easy", "minicraft.settings.difficulty.normal", "minicraft.settings.difficulty.hard"));
 		options.get("diff").setSelection(1);
@@ -81,20 +81,25 @@ public final class Settings {
 	}
 
 	/**
-	 * Gets the refresh rate of the default monitor.
+	 * Gets the double of the refresh rate of the default monitor and rounds down the value to the nearest 10.
 	 * Safely handles headless environments (if that were to happen for some reason).
-	 * @return The refresh rate if successful. 60 if not.
+	 * @return The refresh rate if successful. 120 if not. 120 (double) is more optimal than 60.
 	 */
 	private static int getDefaultRefreshRate() {
 		int hz;
 		try {
-			hz = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate();
+			hz = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate()
+				* 2; // Double the refresh rate as the max FPS value, which could make the rendering optimal without unstable tearing.
 		} catch (HeadlessException e) {
-			return 60;
+			return 120;
 		}
 
-		if (hz == DisplayMode.REFRESH_RATE_UNKNOWN) return 60;
-		if (hz > 300 || 10 >= hz) return 60;
-		return hz;
+		if (hz == DisplayMode.REFRESH_RATE_UNKNOWN) return 120;
+		if (hz > 300) {
+			return 300;
+		} else if (10 >= hz) {
+			return 10;
+		}
+		return hz % 10 == 0 ? hz : hz - hz % 10;
 	}
 }

--- a/src/client/java/minicraft/screen/entry/RangeEntry.java
+++ b/src/client/java/minicraft/screen/entry/RangeEntry.java
@@ -1,31 +1,38 @@
 package minicraft.screen.entry;
 
+import minicraft.util.MyUtils;
+
 public class RangeEntry extends ArrayEntry<Integer> {
-	
-	private static Integer[] getIntegerArray(int min, int max) {
-		Integer[] ints = new Integer[max - min + 1];
-		
+
+	private static Integer[] getIntegerArray(int min, int max, int interval) {
+		Integer[] ints = new Integer[(max - min) / interval + 1];
+
 		for (int i = 0; i < ints.length; i++)
-			ints[i] = min+i;
-		
+			ints[i] = min + i*interval;
+
 		return ints;
 	}
-	
-	private int min, max;
-	
-	public RangeEntry(String label, int min, int max, int initial) {
-		super(label, false, getIntegerArray(min, max));
-		
+
+	private final int min, max;
+	private final int interval;
+
+	@SuppressWarnings("unused") // Reserved for future use
+	public RangeEntry(String label, int min, int max, int initial) { this(label, min, max, initial, 1); }
+	public RangeEntry(String label, int min, int max, int initial, int interval) {
+		super(label, false, getIntegerArray(min, max, interval));
+
 		this.min = min;
 		this.max = max;
-		
+
+		this.interval = interval;
+
 		setValue(initial);
 	}
-	
+
 	@Override
 	public void setValue(Object o) {
 		if (!(o instanceof Integer)) return;
-		
-		setSelection(((Integer)o)-min);
+
+		setSelection(MyUtils.clamp((((Integer)o)-min) / interval, min, max));
 	}
 }


### PR DESCRIPTION
As described, this redoes changes made by #503 except the change to file loading. The change has original been made by #457, which is from interval of 1 to 10 in FPS setting values. It could reduce the time in changing the setting value as multiples of 10 are commonly used values. Also, the default FPS setting values have been doubled, because a doubled FPS is more optimized in rendering preventing most lagging by frame loss.