### PR TITLE
Fix search bar tackling problem

### DIFF
--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -389,6 +389,11 @@ public class InputHandler implements KeyListener {
 		}); // Return the Key object.
 	}
 
+	/** Mark a physical key as not just clicked. It should be more careful when using this method. */
+	public void toggleOffPhyKey(String key) {
+		getPhysKey(key).clicked = false;
+	}
+
 	/// This method provides a way to press physical keys without actually generating a key event.
 	/*public void pressKey(String keyname, boolean pressed) {
 		Key key = getPhysKey(keyname);

--- a/src/client/java/minicraft/screen/Menu.java
+++ b/src/client/java/minicraft/screen/Menu.java
@@ -204,7 +204,7 @@ public class Menu {
 						continue;
 					}
 
-					input.getKey(pressedKey).clicked = false;
+					input.toggleOffPhyKey(pressedKey);
 				}
 
 				// check if word was updated


### PR DESCRIPTION
As there is change in `InputHandler#getKey` that it returns a new object instead of the original physical keyboard key object, changes applied to the objects returned are not reflected in global key objects. This makes an ability to toggle off physical keyboard key objects `Key#clicked` and lets the menu handle search bar input once the input has been made.