### PR TITLE
Fix Gradle run problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,10 @@ jar {
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }}
 }
 
+application { // Execute only client main class
+    mainClass = "minicraft.core.Game"
+}
+
 // Don't override if we're building a tar package.
 tasks.withType(Tar){
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE


### PR DESCRIPTION
As there is a change to the project structure, if it is running without further configuration, server would also be executed, which is not intended. This resolves this problem by overriding the main class of client.