### PR TITLE
Modify spawner behavior

### DIFF
--- a/src/client/java/minicraft/entity/furniture/Spawner.java
+++ b/src/client/java/minicraft/entity/furniture/Spawner.java
@@ -1,6 +1,7 @@
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;
+import minicraft.core.Updater;
 import minicraft.core.io.Sound;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.Cow;
@@ -31,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.tinylog.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
 public class Spawner extends Furniture {
@@ -122,6 +124,12 @@ public class Spawner extends Furniture {
 	private void trySpawn() {
 		if (level == null) return;
 		if (level.mobCount >= level.maxMobCount) return; // Can't spawn more entities
+		if (mob instanceof EnemyMob) {
+			if (level.depth >= 0 && Updater.tickCount > Updater.sleepEndTime && Updater.tickCount < Updater.sleepStartTime)
+				return; // Do not spawn if it is on the surface or above and it is under daylight.
+			if (level.isLight(x >> 4, y >> 4))
+				return;
+		}
 
 		Player player = getClosestPlayer();
 		if (player == null) return;

--- a/src/client/java/minicraft/level/Level.java
+++ b/src/client/java/minicraft/level/Level.java
@@ -9,6 +9,7 @@ import minicraft.entity.Entity;
 import minicraft.entity.ItemEntity;
 import minicraft.entity.furniture.Chest;
 import minicraft.entity.furniture.DungeonChest;
+import minicraft.entity.furniture.Lantern;
 import minicraft.entity.furniture.Spawner;
 import minicraft.entity.mob.AirWizard;
 import minicraft.entity.mob.Cow;
@@ -862,6 +863,12 @@ public class Level {
 		for (Tile t: getAreaTiles(x, y, 3))
 			if (t instanceof TorchTile)
 				return true;
+		for (Entity e : getEntitiesOfClass(Lantern.class)) {
+			if (e instanceof Lantern) {
+				if (Math.hypot((e.x >> 4) - x, (e.y >> 4) - y) < e.getLightRadius() - 1)
+					return true;
+			}
+		}
 
 		return false;
 	}


### PR DESCRIPTION
Now (enemy mobs only) spawners prevent spawning once they are within light. Also, for general light calculation for entities, lanterns are also taken into account as being a light source similar to torch (and more powerful than torch).