### PR TITLE
Add more End Game equipment

### DIFF
--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -322,7 +322,7 @@ public class Renderer extends Game {
 		if (player.activeItem instanceof ToolItem) {
 			// Draws the text
 			ToolItem tool = (ToolItem) player.activeItem;
-			int dura = tool.dur * 100 / (tool.type.durability * (tool.level + 1));
+			int dura = tool.dur * 100 / tool.MAX_DUR;
 			int green = (int) (dura * 2.55f); // Let duration show as normal.
 			Font.drawBackground(dura + "%", screen, 164, Screen.h - 16, Color.get(1, 255 - green, green, 0));
 		}

--- a/src/client/java/minicraft/entity/furniture/DarkAnvil.java
+++ b/src/client/java/minicraft/entity/furniture/DarkAnvil.java
@@ -1,0 +1,102 @@
+package minicraft.entity.furniture;
+
+import minicraft.core.Game;
+import minicraft.entity.mob.Player;
+import minicraft.gfx.SpriteLinker;
+import minicraft.item.StackableItem;
+import minicraft.screen.DarkAnvilDisplay;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DarkAnvil extends Furniture {
+	private static final SpriteLinker.LinkedSprite sprite = new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Entity, "dark_anvil");
+	private static final SpriteLinker.LinkedSprite itemSprite = new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Item, "dark_anvil");
+
+	public static final int MAX_ENERGY = 8;
+
+	private int energy = 0;
+
+	private StackableItem fuelStore = null;
+
+	public DarkAnvil() {
+		super("Dark Anvil", sprite, itemSprite);
+	}
+
+	public int getEnergy() {
+		return energy;
+	}
+
+	/** Try to refill energy using cloud ore in storage.
+	 * @return {@code true} if there was no energy left and successfully refilled */
+	public boolean tryRefillEnergy() {
+		if (energy == 0 && fuelStore != null) {
+			boolean success = false;
+			if (fuelStore.count > 0) {
+				fuelStore.count--;
+				energy = MAX_ENERGY;
+				success = true;
+			}
+
+			if (fuelStore.count == 0) fuelStore = null;
+			return success;
+		}
+
+		return false;
+	}
+
+	public @Nullable StackableItem withdrawStore(boolean all) {
+		if (fuelStore == null) return null;
+		StackableItem item;
+		if (all) {
+			item = fuelStore;
+			fuelStore = null;
+		} else {
+			item = fuelStore.copy();
+			item.count = 1;
+			fuelStore.count--;
+			if (fuelStore.isDepleted()) fuelStore = null;
+		}
+		return item;
+	}
+
+	public int getStore() {
+		if (fuelStore == null) return 0;
+		return fuelStore.count;
+	}
+
+	/** @return {@code true} if 1 energy point is successfully deducted */
+	public boolean deduceEnergy() {
+		if (energy > 0) {
+			energy--;
+			return true;
+		}
+
+		return false;
+	}
+
+	/** @return {@code true} if the provided {@code item} is not depleted */
+	public boolean depositStore(StackableItem item) {
+		if (item.getName().equalsIgnoreCase("Cloud Ore")) {
+			if (!item.isDepleted()) {
+				int toAdd = Math.min(item.count, fuelStore.maxCount - fuelStore.count);
+				fuelStore.count += toAdd;
+				item.count -= toAdd;
+			}
+
+			return !item.isDepleted();
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean use(Player player) {
+		Game.setDisplay(new DarkAnvilDisplay(this, player));
+		return true;
+	}
+
+	@Override
+	public @NotNull Furniture copy() {
+		return new DarkAnvil();
+	}
+}

--- a/src/client/java/minicraft/item/ToolItem.java
+++ b/src/client/java/minicraft/item/ToolItem.java
@@ -31,6 +31,7 @@ public class ToolItem extends Item {
 	private Random random = new Random();
 
 	public static final String[] LEVEL_NAMES = {"Wood", "Rock", "Iron", "Gold", "Gem"}; // The names of the different levels. A later level means a stronger tool.
+	public final int MAX_DUR;
 
 	public ToolType type; // Type of tool (Sword, hoe, axe, pickaxe, shovel)
 	public int level; // Level of said tool
@@ -50,14 +51,14 @@ public class ToolItem extends Item {
 		this.level = level;
 		this.damage = level * 5 + 10;
 
-		dur = type.durability * (level + 1); // Initial durability fetched from the ToolType
+		dur = MAX_DUR = type.durability * (level + 1); // Initial durability fetched from the ToolType
 	}
 
 	public ToolItem(ToolType type) {
 		super(type.name(), new LinkedSprite(SpriteType.Item, getSpriteName(type.toString(), "")));
 
 		this.type = type;
-		dur = type.durability;
+		dur = MAX_DUR = type.durability;
 	}
 
 	/** Gets the name of this tool (and it's type) as a display string. */

--- a/src/client/java/minicraft/screen/DarkAnvilDisplay.java
+++ b/src/client/java/minicraft/screen/DarkAnvilDisplay.java
@@ -1,0 +1,243 @@
+package minicraft.screen;
+
+import minicraft.core.io.InputHandler;
+import minicraft.entity.furniture.DarkAnvil;
+import minicraft.entity.mob.Player;
+import minicraft.gfx.Color;
+import minicraft.gfx.Point;
+import minicraft.gfx.Screen;
+import minicraft.gfx.SpriteLinker;
+import minicraft.item.Inventory;
+import minicraft.item.Item;
+import minicraft.item.Items;
+import minicraft.item.StackableItem;
+import minicraft.item.ToolItem;
+import minicraft.screen.entry.ListEntry;
+import minicraft.screen.entry.SelectEntry;
+import minicraft.screen.entry.SlotEntry;
+import minicraft.screen.entry.StringEntry;
+
+import java.util.ArrayList;
+
+public class DarkAnvilDisplay extends Display {
+	private final int DARKER_GRAY = Color.tint(Color.DARK_GRAY, -1, true);
+	private static final int padding = 10;
+
+	private final Player player;
+	private final DarkAnvil darkAnvil;
+	private final DarkAnvilCarrier carrier;
+
+	private final Menu.Builder darkAnvilMenuBuilder = new Menu.Builder(true, 0, RelPos.LEFT)
+		.setPositioning(new Point(9, 9), RelPos.BOTTOM_RIGHT)
+		.setSelectable(true)
+		.setTitle("Dark Anvil");
+
+	public DarkAnvilDisplay(DarkAnvil darkAnvil, Player player) {
+		super(new InventoryMenu(player, player.getInventory(), "minicraft.display.menus.inventory", RelPos.RIGHT));
+		this.player = player;
+		this.darkAnvil = darkAnvil;
+		carrier = new DarkAnvilCarrier();
+		menus = new Menu[] { darkAnvilMenuBuilder.setEntries(getEntries()).createMenu(), menus[0] };
+		menus[1].translate(menus[0].getBounds().getWidth() + padding, 0);
+	}
+
+	private ArrayList<ListEntry> getEntries() {
+		ArrayList<ListEntry> entries = new ArrayList<>();
+
+		// The first space is reserved for item sprite.
+		int energy = darkAnvil.getEnergy();
+		SpriteLinker.LinkedSprite sprite = Items.get("Cloud Ore").sprite;
+		entries.add(new StringEntry("  " + (energy / DarkAnvil.MAX_ENERGY) + "% (" + darkAnvil.getStore() + ")",
+			energy > 0 ? Color.WHITE : Color.GRAY, false) {
+			@Override
+			public void render(Screen screen, int x, int y, boolean isSelected) {
+				super.render(screen, x, y, isSelected);
+				screen.render(x, y, sprite);
+			}
+		});
+
+		entries.add(carrier.toolSlot);
+		entries.add(carrier.materialSlot);
+		entries.add(carrier.actionEntry);
+		entries.add(carrier.productSlot);
+
+		return entries;
+	}
+
+	@Override
+	protected void onSelectionChange(int oldSel, int newSel) {
+		super.onSelectionChange(oldSel, newSel);
+		if(oldSel == newSel) return; // this also serves as a protection against access to menus[0] when such may not exist.
+		int shift = 0;
+		if(newSel == 0) shift = padding - menus[0].getBounds().getLeft();
+		if(newSel == 1) shift = (Screen.w - padding) - menus[1].getBounds().getRight();
+		for(Menu m: menus)
+			m.translate(shift, 0);
+	}
+
+	@Override
+	public void tick(InputHandler input) {
+		super.tick(input);
+		// Focusing on player inventory
+		if (selection == 1 && (input.inputPressed("attack"))) {
+			if (menus[1].getEntries().length == 0) return;
+			int sel = menus[1].getSelection();
+			Inventory inv = player.getInventory();
+			Item item = inv.get(sel);
+
+			boolean transferAll = input.getKey("SHIFT").down || !(item instanceof StackableItem) || ((StackableItem)item).count == 1;
+			Item toItem = item.copy();
+			if (item instanceof StackableItem) {
+				int move = 1;
+				if (!transferAll) {
+					((StackableItem) toItem).count = 1;
+				} else {
+					move = ((StackableItem) item).count;
+				}
+
+				int moved = carrier.addToCarrier(toItem);
+				if (moved != 0) {
+					if (moved < move) {
+						((StackableItem) item).count -= moved;
+					} else if (!transferAll) {
+						((StackableItem) item).count--;
+					} else {
+						inv.remove(sel);
+					}
+					update();
+				}
+			} else {
+				int moved = carrier.addToCarrier(toItem);
+				if (moved == 1) {
+					inv.remove(sel);
+					update();
+				}
+			}
+		}
+	}
+
+	private void onSlotTransfer(SlotEntry slot, InputHandler input) {
+		Item item = slot.getItem();
+		if (item == null) return;
+		boolean transferAll = input.getKey("SHIFT").down || !(item instanceof StackableItem) || ((StackableItem) item).count == 1;
+		if (item instanceof StackableItem) {
+			Item toItem = item.copy();
+			int move = 1;
+			if (!transferAll) {
+				((StackableItem)toItem).count = 1;
+			} else {
+				move = ((StackableItem) item).count;
+			}
+
+			int moved = player.getInventory().add(toItem);
+			if (moved != 0) {
+				if (moved < move) {
+					((StackableItem) item).count -= moved;
+				} else if (!transferAll) {
+					((StackableItem) item).count--;
+				} else {
+					slot.setItem(null);
+				}
+				update();
+			}
+		} else {
+			int moved = player.getInventory().add(item);
+			if (moved == 1) {
+				slot.setItem(null);
+				update();
+			}
+		}
+	}
+
+	private void update() {
+		// On (slot) update; refresh actionEntry and product (for productSlot)
+		Item item; // Product slot should be empty for this to work.
+		if ((item = carrier.toolSlot.getItem()) != null && carrier.productSlot.getItem() == null) {
+			carrier.product = (ToolItem) item.copy();
+			carrier.product.dur = carrier.product.MAX_DUR;
+			StackableItem material;
+			carrier.actionEntry.setSelectable((material = (StackableItem) carrier.materialSlot.getItem()) != null &&
+				material.count >= carrier.product.level + 1);
+		} else {
+			carrier.product = null;
+			carrier.actionEntry.setSelectable(false);
+		}
+
+		// Generic menu update
+		menus[0] = darkAnvilMenuBuilder.setEntries(getEntries()).createMenu();
+		menus[1] = new InventoryMenu((InventoryMenu) menus[1]);
+		menus[1].translate(menus[0].getBounds().getWidth() + padding, 0);
+		onSelectionChange(0, selection);
+	}
+
+	// A temporary carrier of a dark anvil (for item slots)
+	private class DarkAnvilCarrier {
+		private final SlotEntry toolSlot;
+		private final SlotEntry materialSlot; // Cloud Ore
+		private final SlotEntry.TemporarySlotEntry productSlot;
+		private final SelectEntry actionEntry;
+		private ToolItem product = null;
+
+		public DarkAnvilCarrier() {
+			toolSlot = new SlotEntry(new SlotEntry.SlotEntryPlaceholder("Tool Item"), DarkAnvilDisplay.this::onSlotTransfer);
+			materialSlot = new SlotEntry(new SlotEntry.SingletonItemSlotEntryPlaceholder(Items.get("Cloud Ore")), DarkAnvilDisplay.this::onSlotTransfer);
+			productSlot = new SlotEntry.TemporarySlotEntry(new SlotEntry.SlotEntryPlaceholder("Repaired tool") {
+				@Override
+				public String getDisplayString() {
+					return product == null ? super.getDisplayString() : product.getDisplayName();
+				}
+
+				@Override
+				public int getDisplayColor(boolean isSelected) {
+					return product == null ? DARKER_GRAY : super.getDisplayColor(isSelected);
+				}
+			}, DarkAnvilDisplay.this::onSlotTransfer);
+			actionEntry = new SelectEntry("Repair tool", this::onAction) {
+				@Override
+				public int getColor(boolean isSelected) {
+					return isSelectable() ? super.getColor(isSelected) : Color.DARK_GRAY;
+				}
+			};
+			actionEntry.setSelectable(false);
+		}
+
+		private void onAction() {
+			ToolItem tool = (ToolItem) toolSlot.getItem();
+			StackableItem material = (StackableItem) materialSlot.getItem();
+			// Checking again for security
+			if (tool != null && material != null && material.count >= tool.level + 1) {
+				toolSlot.setItem(null);
+				material.count -= tool.level + 1;
+				productSlot.setItem(product);
+			}
+
+			update(); // Refreshing again
+		}
+
+		/** @return number of items transferred */
+		private int addToCarrier(Item item) {
+			if (item instanceof ToolItem) { // toolSlot
+				if (toolSlot.getItem() == null) {
+					toolSlot.setItem(item);
+					return 1;
+				}
+			} else if (item.getName().equalsIgnoreCase("Cloud Ore")) { // materialSlot
+				StackableItem stack = (StackableItem) materialSlot.getItem();
+				StackableItem toItem = (StackableItem) item.copy();
+				if (stack == null) {
+					toItem.count = Math.min(((StackableItem) item).count, toItem.maxCount);
+					materialSlot.setItem(toItem);
+					((StackableItem) item).count -= toItem.count;
+					return toItem.count;
+				} else if (stack.count < stack.maxCount) {
+					int toAdd = Math.min(((StackableItem) item).count, stack.maxCount - stack.count);
+					stack.count += toAdd;
+					((StackableItem) item).count -= toAdd;
+					return toAdd;
+				}
+			}
+
+			return 0;
+		}
+	}
+}

--- a/src/client/java/minicraft/screen/entry/SlotEntry.java
+++ b/src/client/java/minicraft/screen/entry/SlotEntry.java
@@ -1,0 +1,113 @@
+package minicraft.screen.entry;
+
+import minicraft.core.io.InputHandler;
+import minicraft.core.io.Localization;
+import minicraft.core.io.Sound;
+import minicraft.gfx.Color;
+import minicraft.gfx.Font;
+import minicraft.gfx.Screen;
+import minicraft.gfx.SpriteLinker;
+import minicraft.item.Item;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SlotEntry extends ListEntry {
+	private final SlotInteractionListener onSelect;
+	private final SlotEntryPlaceholder placeholder;
+
+	private @Nullable Item item; // null when empty
+
+	public SlotEntry(@NotNull SlotEntryPlaceholder placeholder, @Nullable SlotInteractionListener onSelect) {
+		this.onSelect = onSelect;
+		this.placeholder = placeholder;
+	}
+
+	// Item depletion is not handled here by itself.
+
+	public void setItem(@Nullable Item item) {
+		this.item = item;
+	}
+
+	public @Nullable Item getItem() {
+		return item;
+	}
+
+	@Override
+	public void tick(InputHandler input) {
+		if (input.inputPressed("select") && onSelect != null) {
+			Sound.play("confirm");
+			onSelect.onInteract(this, input);
+		}
+	}
+
+	@Override
+	public void render(Screen screen, int x, int y, boolean isSelected) {
+		super.render(screen, x, y, isSelected);
+		SpriteLinker.LinkedSprite sprite;
+		if (item == null && (sprite = placeholder.getSprite()) != null)
+			screen.render(x, y, sprite);
+		else
+			screen.render(x, y, item.sprite);
+	}
+
+	@Override
+	public int getColor(boolean isSelected) {
+		return item == null ? placeholder.getDisplayColor(isSelected) : super.getColor(isSelected);
+	}
+
+	@Override
+	public String toString() {
+		return item == null ? placeholder.getDisplayString() : item.getDisplayName();
+	}
+
+	@FunctionalInterface
+	public interface SlotInteractionListener {
+		void onInteract(SlotEntry slot, InputHandler input);
+	}
+
+	public static class SlotEntryPlaceholder {
+		private static final int LIGHT_GRAY = Color.tint(Color.GRAY, 1, true);
+
+		private final String text;
+		private final @Nullable SpriteLinker.LinkedSprite sprite;
+
+		public SlotEntryPlaceholder(String text) { this(text, null); }
+		public SlotEntryPlaceholder(String text, @Nullable SpriteLinker.LinkedSprite sprite) {
+			this.text = text;
+			this.sprite = sprite;
+		}
+
+		public String getDisplayString() { return text; }
+		public int getDisplayColor(boolean isSelected) { return isSelected ? LIGHT_GRAY : Color.DARK_GRAY; }
+		/** @return must be an 8*8 (1*1 block) LinkedSprite */
+		public @Nullable SpriteLinker.LinkedSprite getSprite() { return sprite; }
+	}
+
+	public static class SingletonItemSlotEntryPlaceholder extends SlotEntryPlaceholder {
+		public SingletonItemSlotEntryPlaceholder(@NotNull Item item) {
+			super(Localization.getLocalized(item.getName()), item.sprite);
+		}
+	}
+
+	@SuppressWarnings("unused") // Reserved for future use
+	public static class ReadonlySlotEntry extends SlotEntry {
+		public ReadonlySlotEntry(@NotNull SlotEntryPlaceholder placeholder) {
+			super(placeholder, null);
+			setSelectable(false);
+		}
+	}
+
+	/** Non-selectable when no item is in this slot */
+	public static class TemporarySlotEntry extends SlotEntry {
+		public TemporarySlotEntry(@NotNull SlotEntryPlaceholder placeholder, @Nullable SlotInteractionListener onSelect) {
+			super(placeholder, onSelect);
+			setSelectable(false);
+		}
+
+		@Override
+		public void setItem(@Nullable Item item) {
+			super.setItem(item);
+			setSelectable(item != null);
+		}
+	}
+}


### PR DESCRIPTION
This adds more End Game equipment, originally from #444.
This would come together with #444 or another pull request that implements "curse" in expanding storyline.

This adds:
- Dark Anvil (idea by @Litorom) - made from knight shards and cloud ores; costs cloud ore to repair tools.