### PR TITLE
Optimize CPU usage

### DIFF
--- a/src/client/java/minicraft/core/Initializer.java
+++ b/src/client/java/minicraft/core/Initializer.java
@@ -96,7 +96,7 @@ public class Initializer extends Game {
 			}
 
 			now = System.nanoTime();
-			if (now >= lastRender + 1E9D / MAX_FPS / 1.05) {
+			if (now >= lastRender + 1E9D / MAX_FPS / 1.01) {
 				frames++;
 				lastRender = now;
 				Renderer.render();

--- a/src/client/java/minicraft/core/Initializer.java
+++ b/src/client/java/minicraft/core/Initializer.java
@@ -96,11 +96,22 @@ public class Initializer extends Game {
 			}
 
 			now = System.nanoTime();
-			if (now >= lastRender + 1E9D / MAX_FPS) {
+			if (now >= lastRender + 1E9D / MAX_FPS / 1.05) {
 				frames++;
 				lastRender = now;
 				Renderer.render();
 			}
+
+			try {
+				long curNano = System.nanoTime();
+				long untilNextTick = (long) (lastTick + nsPerTick - curNano);
+				long untilNextFrame = (long) (lastRender + 1E9D / MAX_FPS - curNano);
+				if (untilNextTick > 1E3 && untilNextFrame > 1E3) {
+					double timeToWait = Math.min(untilNextTick, untilNextFrame) / 1.2; // in nanosecond
+					//noinspection BusyWait
+					Thread.sleep((long) Math.floor(timeToWait / 1E6), (int) ((timeToWait - Math.floor(timeToWait)) % 1E6));
+				}
+			} catch (InterruptedException ignored) {}
 
 			if (System.currentTimeMillis() - lastTimer1 > 1000) { //updates every 1 second
 				long interval = System.currentTimeMillis() - lastTimer1;

--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -114,8 +114,6 @@ public class InputHandler implements KeyListener {
 		} catch (ControllerUnpluggedException e) {
 			Logging.CONTROLLER.debug("No Controllers Detected, moving on.");
 		}
-
-		lastInputActivityListener.start();
 	}
 	public InputHandler(Component inputSource) {
 		this();
@@ -206,6 +204,8 @@ public class InputHandler implements KeyListener {
 			for (Key key: keyboard.values())
 				key.tick(); // Call tick() for each key.
 		}
+
+		lastInputActivityListener.tick();
 
 		// Also update the controller button state.
 		for (ControllerButton btn : ControllerButton.values()) {
@@ -632,24 +632,15 @@ public class InputHandler implements KeyListener {
 		}
 	}
 
-	private class LastInputActivityListener extends Thread {
+	private class LastInputActivityListener {
 		public long lastKeyActivityTimestamp = 0;
 		public long lastButtonActivityTimestamp = 0;
 
-		public LastInputActivityListener() {
-			super("LastInputActivityListener");
-		}
-
-		@Override
-		public void run() {
-			while (true) {
-				if (getAllPressedKeys().size() > 0)
-					lastKeyActivityTimestamp = System.currentTimeMillis();
-				if (getAllPressedButtons().size() > 0)
-					lastButtonActivityTimestamp = System.currentTimeMillis();
-				if (isInterrupted())
-					return;
-			}
+		public void tick() {
+			if (getAllPressedKeys().size() > 0)
+				lastKeyActivityTimestamp = System.currentTimeMillis();
+			if (getAllPressedButtons().size() > 0)
+				lastButtonActivityTimestamp = System.currentTimeMillis();
 		}
 	}
 }


### PR DESCRIPTION
In my test with VisualVM profiler, it is unknown that the while loop processing without `Updater#tick()` or `Renderer#render()` invokes occupying relatively great amount of CPU time in self-time. According to my computer, this reduces averagely around 60%-70% of CPU usage in title screen and 50% in a just created world. A thread blocking/sleeping is always needed to prevent while loop looping with empty body using indefinite amount of CPU time. This also presents in the original Minicraft `Game#run()` code (with `Thread#sleep(2)`). `1.01` in the FPS time check is used for relax the hard FPS restriction to prevent from running down the maximum value.
Reference: https://stackoverflow.com/a/61598906