### PR TITLE
Implement "curse" into the game

### DIFF
--- a/src/client/java/minicraft/entity/mob/Cow.java
+++ b/src/client/java/minicraft/entity/mob/Cow.java
@@ -10,6 +10,8 @@ import minicraft.level.tile.Tiles;
 public class Cow extends PassiveMob {
 	private static LinkedSprite[][] sprites = Mob.compileMobSpriteAnimations(0, 0, "cow");
 
+	private boolean followingPlayer = false;
+
 	/**
 	 * Creates the cow with the right sprites and color.
 	 */
@@ -38,5 +40,32 @@ public class Cow extends PassiveMob {
 				level.setTile(x >> 4, y >> 4, Tiles.get("dirt"));
 			}
 		}
+
+		followingPlayer = false;
+		if (AirWizard.beaten) { // When there is no curse
+			Player player;
+			double distance = 0;
+			// If the player is close
+			if ((player = level.getClosestPlayer(x, y)) != null && (distance = Math.hypot(x - player.x, y - player.y)) < 6 * 16) {
+				// If the player is holding a wheat item
+				if (player.activeItem != null && player.activeItem.getName().equalsIgnoreCase("Wheat")) {
+					followingPlayer = true;
+					xmov = 0; // Reset velocity
+					ymov = 0;
+				}
+			}
+
+			if (followingPlayer && distance > 1.5 * 16) {
+				double theta = Math.atan2(player.y - y, player.x - x);
+				int xMov = (int) (speed * 2.2 * Math.cos(theta));
+				int yMov = (int) (speed * 2.2 * Math.sin(theta));
+				move(xMov, yMov);
+			}
+		}
+	}
+
+	@Override
+	protected boolean skipTick() {
+		return !followingPlayer && super.skipTick(); // Skip tick if following a player
 	}
 }

--- a/src/client/java/minicraft/entity/mob/Mob.java
+++ b/src/client/java/minicraft/entity/mob/Mob.java
@@ -129,12 +129,12 @@ public abstract class Mob extends Entity {
 
 	/** The mob immediately despawns if the distance of the closest player is greater than the return value of this. */
 	protected int getDespawnDistance() {
-		return 80;
+		return 512;
 	}
 
 	/** The mob randomly despawns if the distance of the closest player is greater than the return value of this. */
 	protected int getNoDespawnDistance() {
-		return 40;
+		return 256;
 	}
 
 	/** @see #handleDespawn() */

--- a/src/client/java/minicraft/entity/mob/Sheep.java
+++ b/src/client/java/minicraft/entity/mob/Sheep.java
@@ -19,6 +19,8 @@ public class Sheep extends PassiveMob {
 
 	public boolean cut = false;
 
+	private boolean followingPlayer = false;
+
 	/**
 	 * Creates a sheep entity.
 	 */
@@ -52,6 +54,28 @@ public class Sheep extends PassiveMob {
 				cut = false;
 			}
 		}
+
+		followingPlayer = false;
+		if (AirWizard.beaten) { // When there is no curse
+			Player player;
+			double distance = 0;
+			// If the player is close
+			if ((player = level.getClosestPlayer(x, y)) != null && (distance = Math.hypot(x - player.x, y - player.y)) < 6) {
+				// If the player is holding a wheat item
+				if (player.activeItem != null && player.activeItem.getName().equalsIgnoreCase("Wheat")) {
+					followingPlayer = true;
+					xmov = 0; // Reset velocity
+					ymov = 0;
+				}
+			}
+
+			if (followingPlayer && distance > 2) {
+				double theta = Math.atan2(player.y - y, player.x - x);
+				int xMov = (int) (speed * Math.cos(theta));
+				int yMov = (int) (speed * Math.sin(theta));
+				move(xMov, yMov);
+			}
+		}
 	}
 
 	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
@@ -78,5 +102,9 @@ public class Sheep extends PassiveMob {
 		dropItem(min, max, Items.get("Raw Beef"));
 
 		super.die();
+	}
+
+	protected boolean skipTick() {
+		return !followingPlayer && super.skipTick(); // Skip tick if following a player
 	}
 }


### PR DESCRIPTION
There is an idea about "curse", which is the curse of "alone" applying on the player with the living Air Wizard. When Air Wizard dies, the curse is also broken, then the player can be no longer alone from animals with kind minds.
This adds behaviors to the animal cow and sheep. When the player is holding wheats with the curse broken, those animals would follow to the player with distance. Also, this fixes the problem that mob despawning too close to the player. The ability to feed animals might also be added.