### PR TITLE
Fix furniture holding player sprites missing

### DIFF
--- a/src/client/java/minicraft/screen/SkinDisplay.java
+++ b/src/client/java/minicraft/screen/SkinDisplay.java
@@ -195,7 +195,7 @@ public class SkinDisplay extends Display {
 			String skinPath = file.getName();
 			String name = skinPath.substring(0, skinPath.length() - 4);
 			if (file.exists()) try {
-				MinicraftImage sheet = new MinicraftImage(ImageIO.read(new FileInputStream(file)), 64, 16);
+				MinicraftImage sheet = new MinicraftImage(ImageIO.read(new FileInputStream(file)), 64, 32);
 				Renderer.spriteLinker.setSkin("skin." + name, sheet);
 				skins.put(name, Mob.compileMobSpriteAnimations(0, 0, "skin." + name));
 			} catch (IOException e) {


### PR DESCRIPTION
This reverts a change by da6d4799577222c3ad12007c7005c454a382f6ef in #413. In fact, the first line (0, 0, 64, 16) contains normal skins and the second line (0, 16, 64, 16) contains furniture holding skins, so this is a mistake of determining this as redundant. The current sheet does not include the second line, so this leads to a texture missing in furniture holding rendering.