### PR TITLE
Add Knight Statue limit and fix Obsidian Knight phase problem

### DIFF
--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -16,6 +16,7 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker;
 import minicraft.item.Items;
 import minicraft.screen.AchievementsDisplay;
+import org.jetbrains.annotations.Range;
 
 public class ObsidianKnight extends EnemyMob {
 	private static final SpriteLinker.LinkedSprite[][][] armored = new SpriteLinker.LinkedSprite[][][] {
@@ -36,8 +37,9 @@ public class ObsidianKnight extends EnemyMob {
 	public static boolean beaten = false; // If the boss was beaten
 	public static boolean active = false; // If the boss is active
 
-	private static int phase = 0; // The phase of the boss. {0, 1}
-	private static int attackPhaseCooldown = 0; // Cooldown between attacks
+	@Range(from = 0, to = 1)
+	private int phase = 0; // The phase of the boss. {0, 1}
+	private int attackPhaseCooldown = 0; // Cooldown between attacks
 
 	private AttackPhase attackPhase = AttackPhase.Attacking;
 	private enum AttackPhase { Attacking, Dashing, Walking; } // Using fire sparks in attacking.
@@ -81,12 +83,9 @@ public class ObsidianKnight extends EnemyMob {
 		if (health <= 2500) {
 			phase = 1;
 		}
-		if (phase == 1) {
+		if (phase == 1) { // Refreshing phased sprites
 			lvlSprites = broken;
-		}
-
-		//Fix for wrong sprite usage when respawned
-		if (health > 2500) {
+		} else {
 			lvlSprites = armored;
 		}
 
@@ -139,7 +138,7 @@ public class ObsidianKnight extends EnemyMob {
 				else if (atan2 < -67.5) attackDir = -90;
 				else if (atan2 < -22.5) attackDir = -45;
 				else attackDir = 0;
-				double speed = 1 + attackLevel * 0.2 + attackTime / 10 * 0.01; // speed is dependent on the attackType. (higher attackType, faster speeds)
+				double speed = 1 + attackLevel * 0.2 + attackTime / 10D * 0.01; // speed is dependent on the attackType. (higher attackType, faster speeds)
 				// The range of attack is 90 degrees. With little random factor.
 				int phi = attackDir - 36 + (attackTime % 5) * 18 + random.nextInt(7) - 3;
 				level.add(new FireSpark(this, Math.cos(Math.toRadians(phi)) * speed, Math.sin(Math.toRadians(phi)) * speed)); // Adds a spark entity with the cosine and sine of dir times speed.

--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -79,14 +79,10 @@ public class ObsidianKnight extends EnemyMob {
 			this.remove();
 		}
 
-		//Achieve phase2
-		if (health <= 2500) {
+		// Achieve phase 2
+		if (health <= 2500 && phase == 0) { // Assume that phase would not turn back to phase 1
 			phase = 1;
-		}
-		if (phase == 1) { // Refreshing phased sprites
-			lvlSprites = broken;
-		} else {
-			lvlSprites = armored;
+			lvlSprites = broken; // Refreshing phased sprites
 		}
 
 		if (Game.isMode("minicraft.settings.mode.creative")) return; // Should not attack if player is in creative

--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -85,6 +85,11 @@ public class ObsidianKnight extends EnemyMob {
 			lvlSprites = broken;
 		}
 
+		//Fix for wrong sprite usage when respawned
+		if (health > 2500) {
+			lvlSprites = armored;
+		}
+
 		if (Game.isMode("minicraft.settings.mode.creative")) return; // Should not attack if player is in creative
 
 		if (attackPhaseCooldown == 0) {

--- a/src/client/java/minicraft/item/SummonItem.java
+++ b/src/client/java/minicraft/item/SummonItem.java
@@ -68,12 +68,15 @@ public class SummonItem extends StackableItem {
 					// If the player nears the center.
 					if (new Rectangle(level.w/2-3, level.h/2-3, 7, 7).contains(player.x >> 4, player.y >> 4)) {
 						if (!ObsidianKnight.active) {
-
-							// Pay stamina
-							if (player.payStamina(2)) {
-								level.add(new KnightStatue(5000), level.w/2, level.h/2, true);
-								Logger.tag("SummonItem").debug("Summoned new Knight Statue");
-								success = true;
+							if (level.getEntitiesOfClass(KnightStatue.class).length == 0) { // Prevent unintended behaviors
+								// Pay stamina
+								if (player.payStamina(2)) {
+									level.add(new KnightStatue(5000), level.w/2, level.h/2, true);
+									Logger.tag("SummonItem").debug("Summoned new Knight Statue");
+									success = true;
+								}
+							} else {
+								Game.notifications.add(Localization.getLocalized("minicraft.notification.knight_statue_exists"));
 							}
 						} else {
 							Game.notifications.add(Localization.getLocalized("minicraft.notification.boss_limit"));

--- a/src/client/java/minicraft/item/SummonItem.java
+++ b/src/client/java/minicraft/item/SummonItem.java
@@ -3,6 +3,7 @@ package minicraft.item;
 import minicraft.core.Game;
 import minicraft.core.io.Localization;
 import minicraft.entity.Direction;
+import minicraft.entity.Entity;
 import minicraft.entity.furniture.KnightStatue;
 import minicraft.entity.mob.AirWizard;
 import minicraft.entity.mob.ObsidianKnight;
@@ -68,7 +69,15 @@ public class SummonItem extends StackableItem {
 					// If the player nears the center.
 					if (new Rectangle(level.w/2-3, level.h/2-3, 7, 7).contains(player.x >> 4, player.y >> 4)) {
 						if (!ObsidianKnight.active) {
-							if (level.getEntitiesOfClass(KnightStatue.class).length == 0) { // Prevent unintended behaviors
+							boolean exists = false;
+							for (Entity e : level.getEntityArray()) {
+								if (e instanceof KnightStatue) {
+									exists = true;
+									break;
+								}
+							}
+
+							if (!exists) { // Prevent unintended behaviors
 								// Pay stamina
 								if (player.payStamina(2)) {
 									level.add(new KnightStatue(5000), level.w/2, level.h/2, true);

--- a/src/client/resources/assets/localization/en-us.json
+++ b/src/client/resources/assets/localization/en-us.json
@@ -233,6 +233,7 @@
   "minicraft.notification.wrong_level_dungeon": "Can only be summoned on the dungeon level",
   "minicraft.notification.boss_limit": "No more bosses can be spawned",
   "minicraft.notification.spawn_on_boss_tile": "Can only be summoned in the Boss Room",
+  "minicraft.notification.knight_statue_exists": "A knight statue exists",
   "minicraft.notifications.statue_tapped": "You hear echoed whispers...",
   "minicraft.notifications.statue_touched": "You hear the statue vibrating...",
   "minicraft.quest.farming": "Farming Farmer",


### PR DESCRIPTION
As the number of Knight Statue is unlimited, there can be many Knight Statues placed on the same destination tile. Unintended behaviours might be allowed to happen.
This also includes a fix for Obsidian Knight phase sprite problem.