### PR TITLE
Fix compounded input problem

### DIFF
--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -361,18 +361,48 @@ public class InputHandler implements KeyListener {
 		// Complex compound key binding support.
 		HashSet<Key> keys = new HashSet<>();
 		synchronized ("lock") {
-			String[] split = keytext.split("-");
-			for (String s : split) {
-				if (keyboard.containsKey(s))
-					keys.add(keyboard.get(s)); // Gets the key object from keyboard, if if exists.
-				else {
-					// If the specified key does not yet exist in keyboard, then create a new Key, and put it there.
-					Key key = new Key(); // Make new key
-					keyboard.put(s, key); // Add it to keyboard
-					keys.add(key);
+//			String[] split = keytext.split("-");
+//			for (String s : split) {
+//				if (keyboard.containsKey(s))
+//					keys.add(keyboard.get(s)); // Gets the key object from keyboard, if if exists.
+//				else {
+//					// If the specified key does not yet exist in keyboard, then create a new Key, and put it there.
+//					Key key = new Key(); // Make new key
+//					keyboard.put(s, key); // Add it to keyboard
+//					keys.add(key);
+//
+//					//if(Game.debug) System.out.println("Added new key: \'" + keytext + "\'"); //log to console that a new key was added to the keyboard
+//				}
+//			}
 
-					//if(Game.debug) System.out.println("Added new key: \'" + keytext + "\'"); //log to console that a new key was added to the keyboard
-				}
+			while (true) { // Only handle these 3 modifiers as the key combinations.
+				if (keytext.startsWith("SHIFT-")) {
+					keys.add(keyboard.get("SHIFT"));
+					keytext = keytext.substring(6);
+				} else if (keytext.startsWith("ALT-")) {
+					keys.add(keyboard.get("ALT"));
+					keytext = keytext.substring(4);
+				} else if (keytext.startsWith("CTRL-")) {
+					keys.add(keyboard.get("CTRL"));
+					keytext = keytext.substring(5);
+				} else break; // No more modifiers to be handled
+			}
+
+			if(getFromMap) { // If false, we assume that keytext is a physical key.
+				// If the passed-in key equals one in keymap, then replace it with it's match, a key in keyboard.
+				if (keymap.containsKey(keytext))
+					keytext = keymap.get(keytext); // Converts action name to physical key name
+			}
+
+			if (keyboard.containsKey(keytext))
+				keys.add(keyboard.get(keytext)); // Gets the key object from keyboard, if if exists.
+			else {
+				// If the specified key does not yet exist in keyboard, then create a new Key, and put it there.
+				Key key = new Key(); // Make new key
+				keyboard.put(keytext, key); // Add it to keyboard
+				keys.add(key);
+
+				//if(Game.debug) System.out.println("Added new key: \'" + keytext + "\'"); //log to console that a new key was added to the keyboard
 			}
 		}
 

--- a/src/client/java/minicraft/screen/ContainerDisplay.java
+++ b/src/client/java/minicraft/screen/ContainerDisplay.java
@@ -99,7 +99,7 @@ public class ContainerDisplay extends Display {
 		}
 
 		if (mainMethod || !onScreenKeyboardMenu.isVisible())
-			if (input.inputPressed("attack") || input.getKey("shift-enter").clicked) {
+			if (input.inputPressed("attack") || input.getKey("shift-attack").clicked) {
 				if (curMenu.getEntries().length == 0) return;
 				// switch inventories
 				Inventory from, to;
@@ -116,7 +116,7 @@ public class ContainerDisplay extends Display {
 
 				Item fromItem = from.get(fromSel);
 
-				boolean transferAll = input.getKey("shift-enter").clicked || !(fromItem instanceof StackableItem) || ((StackableItem)fromItem).count == 1;
+				boolean transferAll = input.getKey("shift").down || !(fromItem instanceof StackableItem) || ((StackableItem)fromItem).count == 1;
 
 				Item toItem = fromItem.copy();
 

--- a/src/client/java/minicraft/screen/QuestsDisplay.java
+++ b/src/client/java/minicraft/screen/QuestsDisplay.java
@@ -429,13 +429,13 @@ public class QuestsDisplay extends Display {
 				if (questsTree.length > 0) {
 					if (input.getKey("shift").down) { // Browsing mode.
 						inBrowsing = true;
-						if (input.getKey("shift-down").clicked)
+						if (input.getKey("shift-cursor-down").clicked)
 							yScroll += 3;
-						else if (input.getKey("shift-up").clicked)
+						else if (input.getKey("shift-cursor-up").clicked)
 							yScroll -= 3;
-						else if (input.getKey("shift-right").clicked)
+						else if (input.getKey("shift-cursor-right").clicked)
 							xScroll += 3;
-						else if (input.getKey("shift-left").clicked)
+						else if (input.getKey("shift-cursor-left").clicked)
 							xScroll -= 3;
 					} else {
 						if (inBrowsing) {

--- a/src/client/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/client/java/minicraft/screen/ResourcePackDisplay.java
@@ -322,21 +322,7 @@ public class ResourcePackDisplay extends Display {
 	@Override
 	public void tick(InputHandler input) {
 		// Overrides the default tick handler.
-		if (input.getKey("right").clicked) { // Move cursor to the second list.
-			if (selection == 0) {
-				Sound.play("select");
-				onSelectionChange(0, 1);
-			}
-
-			return;
-		} else if (input.getKey("left").clicked) { // Move cursor to the first list.
-			if (selection == 1) {
-				Sound.play("select");
-				onSelectionChange(1, 0);
-			}
-
-			return;
-		} else if (input.getKey("shift-right").clicked) { // Move the selected pack to the second list.
+		if (input.getKey("shift-cursor-right").clicked) { // Move the selected pack to the second list.
 			if (selection == 0 && resourcePacks.size() > 0) {
 				loadedPacks.add(loadedPacks.indexOf(defaultPack), resourcePacks.remove(menus[0].getSelection()));
 				changed = true;
@@ -345,7 +331,7 @@ public class ResourcePackDisplay extends Display {
 			}
 
 			return;
-		} else if (input.getKey("shift-left").clicked) { // Move the selected pack to the first list.
+		} else if (input.getKey("shift-cursor-left").clicked) { // Move the selected pack to the first list.
 			if (selection == 1 && loadedPacks.get(menus[1].getSelection()) != defaultPack) {
 				resourcePacks.add(loadedPacks.remove(menus[1].getSelection()));
 				changed = true;
@@ -354,7 +340,7 @@ public class ResourcePackDisplay extends Display {
 			}
 
 			return;
-		} else if (input.getKey("shift-up").clicked) { // Move up the selected pack in the second list.
+		} else if (input.getKey("shift-cursor-up").clicked) { // Move up the selected pack in the second list.
 			if (selection == 1 && menus[1].getSelection() > 0) {
 				if (loadedPacks.get(menus[1].getSelection()) == defaultPack) return; // Default pack remains bottom.
 				loadedPacks.add(menus[1].getSelection() - 1, loadedPacks.remove(menus[1].getSelection()));
@@ -364,13 +350,27 @@ public class ResourcePackDisplay extends Display {
 			}
 
 			return;
-		} else if (input.getKey("shift-down").clicked) { // Move down the selected pack in the second list.
+		} else if (input.getKey("shift-cursor-down").clicked) { // Move down the selected pack in the second list.
 			if (selection == 1 && menus[1].getSelection() < loadedPacks.size() - 1) {
 				if (loadedPacks.get(menus[1].getSelection() + 1) == defaultPack) return; // Default pack remains bottom.
 				loadedPacks.add(menus[1].getSelection() + 1, loadedPacks.remove(menus[1].getSelection()));
 				changed = true;
 				refreshEntries();
 				Sound.play("select");
+			}
+
+			return;
+		} else if (input.getKey("cursor-right").clicked) { // Move cursor to the second list.
+			if (selection == 0) {
+				Sound.play("select");
+				onSelectionChange(0, 1);
+			}
+
+			return;
+		} else if (input.getKey("cursor-left").clicked) { // Move cursor to the first list.
+			if (selection == 1) {
+				Sound.play("select");
+				onSelectionChange(1, 0);
 			}
 
 			return;


### PR DESCRIPTION
*This depends on #504*
As there is a problem that the compounded input may not correctly detect inputs compounded with keymaps (modified mapping bindings), this reverts the limitation back to only to "SHIFT", "ALT" and "CTRL". Then, the compounded key bindings are no longer available for most of `F3`-bounded keys, and #504 removes such keys. Besides this, no more keys are associated with keys more than 1 key other than the 3 modifiers. Also, this fixes that some displays (e.g. `ResourcePackDisplay`) do not correctly detect modified keys due to the small change to `InputHandler#getKey` (originally, for example, either `SHIFT-X` or `X` returns `true` with `Key#clicked`; currently, `X` returns `true` even that `SHIFT` is down as this could correctly detect whole key inputs, but some of the input checks were not originally designed by this rule).
If the feature of compounded keys (allowing more than 1 keys other than the 3 modifiers to be compounded) is kept, the strings must have to be modified. For instance, using `+` instead of `-` for key compounding as it conflicts with `-` used for keymaps.