### PR TITLE
Add missing fishing interrupt handles

### DIFF
--- a/src/client/java/minicraft/entity/mob/Player.java
+++ b/src/client/java/minicraft/entity/mob/Player.java
@@ -605,6 +605,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 			activeItem.interactOn(Tiles.get("rock"), level, 0, 0, this, attackDir);
 			if (activeItem.isDepleted()) {
 				activeItem = null;
+				if (isFishing) {
+					isFishing = false;
+					fishingTicks = maxFishingTicks;
+				}
 			}
 			return;
 		}
@@ -663,6 +667,10 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				if (activeItem.isDepleted()) {
 					// If the activeItem has 0 items left, then "destroy" it.
 					activeItem = null;
+					if (isFishing) {
+						isFishing = false;
+						fishingTicks = maxFishingTicks;
+					}
 				}
 			}
 			if (done) return; // Skip the rest if interaction was handled


### PR DESCRIPTION
Similar to #462, but this patches the missing parts that are related to `Item#isDeleted()` checks. The resultant crashes are the same.