### PR TITLE
Fix a problem on missing Display#onExit

### DIFF
--- a/src/client/java/minicraft/core/Updater.java
+++ b/src/client/java/minicraft/core/Updater.java
@@ -126,7 +126,10 @@ public class Updater extends Game {
 			// assert curDisplay == prevDisplay;
 			currentDisplay = displayQuery.peek();
 			assert currentDisplay != null;
-			currentDisplay.init(prevDisplay);
+			if (prevDisplay.getParent() == currentDisplay)
+				prevDisplay.onExit();
+			else
+				currentDisplay.init(prevDisplay);
 		}
 
 		Level level = levels[currentLevel];


### PR DESCRIPTION
This problem causes some displays not working properly depending on `Display#onExit()` invokes. This involves changes by #436 that the display handler is using a `ArrayDeque` and loops.