### PR TITLE
Separate attack action and interact action

### DIFF
--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -325,19 +325,19 @@ public class Renderer extends Game {
 		}
 
 		// This renders the potions overlay
-		if (player.showpotioneffects && player.potioneffects.size() > 0) {
+		if (player.showPotionEffects && player.potioneffects.size() > 0) {
 
 			@SuppressWarnings("unchecked")
 			Map.Entry<PotionType, Integer>[] effects = player.potioneffects.entrySet().toArray(new Map.Entry[0]);
 
 			// The key is potion type, value is remaining potion duration.
-			if (!player.simpPotionEffects) {
+			if (!player.simplifyPotionEffects) {
 				for (int i = 0; i < effects.length; i++) {
 					PotionType pType = effects[i].getKey();
 					int pTime = effects[i].getValue() / Updater.normSpeed;
 					int minutes = pTime / 60;
 					int seconds = pTime % 60;
-					Font.drawBackground(Localization.getLocalized("minicraft.display.gui.potion_effects.hide_hint", input.getMapping("potionEffects")), screen, 180, 9);
+					Font.drawBackground(Localization.getLocalized("minicraft.display.gui.potion_effects.hide_hint", input.getMapping("POTION-EFFECTS")), screen, 180, 9);
 					Font.drawBackground(Localization.getLocalized("minicraft.display.gui.potion_effects.potion_dur", pType, minutes, seconds), screen, 180, 17 + i * Font.textHeight() + potionRenderOffset, pType.dispColor);
 				}
 			} else {

--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -134,10 +134,11 @@ public class InputHandler implements KeyListener {
 		keymap.put("SELECT", "ENTER");
 		keymap.put("EXIT", "ESCAPE");
 
-		keymap.put("QUICKSAVE", "R"); // Saves the game while still playing
+		keymap.put("QUICK-SAVE", "R"); // Saves the game while still playing
 
-		keymap.put("ATTACK", "C|SPACE|ENTER"); // Attack action references "C" key
-		keymap.put("MENU", "X|E"); // And so on... menu does various things.
+		keymap.put("ATTACK", "C|SPACE"); // Attack/destroy action references "C" key
+		keymap.put("INTERACT", "X|ENTER"); // Interact action references "X" key (formerly "menu")
+		keymap.put("INVENTORY", "E"); // Open/close player inventory menu and exit action of some displays.
 		keymap.put("CRAFT", "Z|SHIFT-E"); // Open/close personal crafting window.
 		keymap.put("PICKUP", "V|P"); // Pickup torches / furniture; this replaces the power glove.
 		keymap.put("DROP-ONE", "Q"); // Drops the item in your hand, or selected in your inventory, by ones; it won't drop an entire stack
@@ -152,12 +153,11 @@ public class InputHandler implements KeyListener {
 
 		keymap.put("PAUSE", "ESCAPE"); // Pause the Game.
 
-		keymap.put("POTIONEFFECTS", "P"); // Toggle potion effect display
-		keymap.put("SIMPPOTIONEFFECTS", "O"); // Whether to simplify the potion effect display
-		keymap.put("EXPANDQUESTDISPLAY", "L"); // Expands the quest display
-		keymap.put("TOGGLEHUD", "F1"); // Toggle HUD
+		keymap.put("POTION-EFFECTS", "P"); // Toggle potion effect display
+		keymap.put("SIMPLIFY-POTION-EFFECTS", "O"); // Whether to simplify the potion effect display
+		keymap.put("EXPAND-QUEST-DISPLAY", "L"); // Expands the quest display
+		keymap.put("TOGGLE-HUD", "F1"); // Toggle HUD
 		keymap.put("SCREENSHOT", "F2"); // To make screenshot
-		keymap.put("INFO", "SHIFT-I"); // Toggle player stats display
 
 		keymap.put("FULLSCREEN", "F11");
 	}
@@ -179,16 +179,18 @@ public class InputHandler implements KeyListener {
 		buttonMap.put("EXIT", ControllerButton.B);
 
 		buttonMap.put("ATTACK", ControllerButton.A);
-		buttonMap.put("MENU", ControllerButton.X);
-		buttonMap.put("CRAFT", ControllerButton.Y);
-		buttonMap.put("PICKUP", ControllerButton.LEFTBUMPER);
+		buttonMap.put("INTERACT", ControllerButton.B);
+		buttonMap.put("MENU", ControllerButton.Y);
+		buttonMap.put("CRAFT", ControllerButton.X);
+		buttonMap.put("PICKUP", ControllerButton.LEFTSTICK);
+		buttonMap.put("INVENTORY", ControllerButton.RIGHTSTICK);
 
 		buttonMap.put("SEARCHER-BAR", ControllerButton.START);
 
 		buttonMap.put("PAUSE", ControllerButton.START);
 
-		buttonMap.put("DROP-ONE", ControllerButton.RIGHTBUMPER);
-		buttonMap.put("DROP-STACK", ControllerButton.RIGHTSTICK);
+		buttonMap.put("DROP-ONE", ControllerButton.LEFTBUMPER);
+		buttonMap.put("DROP-STACK", ControllerButton.RIGHTBUMPER);
 	}
 
 	public void resetKeyBindings() {

--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -180,10 +180,9 @@ public class InputHandler implements KeyListener {
 
 		buttonMap.put("ATTACK", ControllerButton.A);
 		buttonMap.put("INTERACT", ControllerButton.B);
-		buttonMap.put("MENU", ControllerButton.Y);
-		buttonMap.put("CRAFT", ControllerButton.X);
+		buttonMap.put("INVENTORY", ControllerButton.X);
+		buttonMap.put("CRAFT", ControllerButton.Y);
 		buttonMap.put("PICKUP", ControllerButton.LEFTSTICK);
-		buttonMap.put("INVENTORY", ControllerButton.RIGHTSTICK);
 
 		buttonMap.put("SEARCHER-BAR", ControllerButton.START);
 

--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -106,13 +106,13 @@ public abstract class Entity implements Tickable {
 	protected void touchedBy(Entity entity) {}
 
 	/**
-	 * Interacts with the entity this method is called on
+	 * Attacks the entity this method is called on
 	 * @param player The player attacking
 	 * @param item The item the player attacked with
 	 * @param attackDir The direction to interact
 	 * @return If the interaction was successful
 	 */
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean attack(Player player, @Nullable Item item, Direction attackDir) {
 		return false;
 	}
 

--- a/src/client/java/minicraft/entity/furniture/Bed.java
+++ b/src/client/java/minicraft/entity/furniture/Bed.java
@@ -23,7 +23,7 @@ public class Bed extends Furniture {
 	}
 
 	/** Called when the player attempts to get in bed. */
-	public boolean use(Player player) {
+	public boolean interact(Player player) {
 		if (checkCanSleep(player)) { // If it is late enough in the day to sleep...
 
 			// Set the player spawn coord. to their current position, in tile coords (hence " >> 4")

--- a/src/client/java/minicraft/entity/furniture/Chest.java
+++ b/src/client/java/minicraft/entity/furniture/Chest.java
@@ -33,8 +33,8 @@ public class Chest extends Furniture implements ItemHolder {
 		inventory = new Inventory(); // Initialize the inventory.
 	}
 
-	/** This is what occurs when the player uses the "Menu" command near this */
-	public boolean use(Player player) {
+	/** This is what occurs when the player uses the "Interact" command near this */
+	public boolean interact(Player player) {
 		Game.setDisplay(new ContainerDisplay(player, this));
 		return true;
 	}
@@ -62,9 +62,9 @@ public class Chest extends Furniture implements ItemHolder {
 	}
 
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean attack(Player player, @Nullable Item item, Direction attackDir) {
 		if (inventory.invSize() == 0)
-			return super.interact(player, item, attackDir);
+			return super.attack(player, item, attackDir);
 		return false;
 	}
 

--- a/src/client/java/minicraft/entity/furniture/Crafter.java
+++ b/src/client/java/minicraft/entity/furniture/Crafter.java
@@ -48,7 +48,7 @@ public class Crafter extends Furniture {
 		this.type = type;
 	}
 
-	public boolean use(Player player) {
+	public boolean interact(Player player) {
 		Game.setDisplay(new CraftingDisplay(type.recipes, type.name(), player));
 		return true;
 	}

--- a/src/client/java/minicraft/entity/furniture/DeathChest.java
+++ b/src/client/java/minicraft/entity/furniture/DeathChest.java
@@ -89,7 +89,7 @@ public class DeathChest extends Chest {
 		Font.draw(timeString, screen, x - Font.textWidth(timeString)/2, y - Font.textHeight() - getBounds().getHeight()/2, Color.WHITE);
 	}
 
-	public boolean use(Player player) { return false; } // can't open it, just walk into it.
+	public boolean interact(Player player) { return false; } // can't open it, just walk into it.
 
 	public void take(Player player) {} // can't grab a death chest.
 

--- a/src/client/java/minicraft/entity/furniture/DungeonChest.java
+++ b/src/client/java/minicraft/entity/furniture/DungeonChest.java
@@ -47,7 +47,7 @@ public class DungeonChest extends Chest {
 		return new DungeonChest(false, !this.isLocked);
 	}
 
-	public boolean use(Player player) {
+	public boolean interact(Player player) {
 		if (isLocked) {
 			boolean activeKey = player.activeItem != null && player.activeItem.equals(Items.get("Key"));
 			boolean invKey = player.getInventory().count(Items.get("key")) > 0;
@@ -72,12 +72,12 @@ public class DungeonChest extends Chest {
 					level.dropItem(x, y, 5, Items.get("Gold Apple"));
 				}
 
-				return super.use(player); // the player unlocked the chest.
+				return super.interact(player); // the player unlocked the chest.
 			}
 
 			return false; // the chest is locked, and the player has no key.
 		}
-		else return super.use(player); // the chest was already unlocked.
+		else return super.interact(player); // the chest was already unlocked.
 	}
 
 	/**
@@ -113,9 +113,9 @@ public class DungeonChest extends Chest {
 	}
 
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean attack(Player player, @Nullable Item item, Direction attackDir) {
 		if(!isLocked)
-			return super.interact(player, item, attackDir);
+			return super.attack(player, item, attackDir);
 		return false;
 	}
 }

--- a/src/client/java/minicraft/entity/furniture/Furniture.java
+++ b/src/client/java/minicraft/entity/furniture/Furniture.java
@@ -70,8 +70,8 @@ public class Furniture extends Entity {
 	/** Draws the furniture on the screen. */
 	public void render(Screen screen) { screen.render(x-8, y-8, sprite); }
 
-	/** Called when the player presses the MENU key in front of this. */
-	public boolean use(Player player) { return false; }
+	/** Called when the player presses the INTERACT key in front of this. */
+	public boolean interact(Player player) { return false; }
 
 	@Override
 	public boolean blocks(Entity e) {
@@ -89,7 +89,7 @@ public class Furniture extends Entity {
 	 * @param player The player picking up the furniture.
 	 */
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean attack(Player player, @Nullable Item item, Direction attackDir) {
 		if (item instanceof PowerGloveItem) {
 			Sound.play("monsterhurt");
 				remove();

--- a/src/client/java/minicraft/entity/furniture/KnightStatue.java
+++ b/src/client/java/minicraft/entity/furniture/KnightStatue.java
@@ -19,7 +19,7 @@ public class KnightStatue extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, Item heldItem, Direction attackDir) {
+	public boolean attack(Player player, Item heldItem, Direction attackDir) {
 		if (!ObsidianKnight.active) {
 			if (touches == 0) { // Touched the first time.
 				Game.notifications.add(Localization.getLocalized("minicraft.notifications.statue_tapped"));

--- a/src/client/java/minicraft/entity/furniture/Spawner.java
+++ b/src/client/java/minicraft/entity/furniture/Spawner.java
@@ -173,7 +173,7 @@ public class Spawner extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, Item item, Direction attackDir) {
+	public boolean attack(Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem)item;
 
@@ -211,13 +211,13 @@ public class Spawner extends Furniture {
 			return true;
 		}
 
-		if (item == null) return use(player);
+		if (item == null) return interact(player);
 
 		return false;
 	}
 
 	@Override
-	public boolean use(Player player) {
+	public boolean interact(Player player) {
 		if (Game.isMode("minicraft.settings.mode.creative") && mob instanceof EnemyMob) {
 			lvl++;
 			if (lvl > maxMobLevel) lvl = 1;

--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -124,7 +124,7 @@ public class Tnt extends Furniture implements ActionListener {
 	}
 
 	@Override
-	public boolean interact(Player player, Item heldItem, Direction attackDir) {
+	public boolean attack(Player player, Item heldItem, Direction attackDir) {
 		if (!fuseLit) {
 			fuseLit = true;
 			Sound.play("fuse");

--- a/src/client/java/minicraft/entity/mob/Player.java
+++ b/src/client/java/minicraft/entity/mob/Player.java
@@ -47,7 +47,6 @@ import minicraft.network.Analytics;
 import minicraft.saveload.Save;
 import minicraft.screen.AchievementsDisplay;
 import minicraft.screen.CraftingDisplay;
-import minicraft.screen.InfoDisplay;
 import minicraft.screen.LoadingDisplay;
 import minicraft.screen.PauseDisplay;
 import minicraft.screen.PlayerInvDisplay;
@@ -120,8 +119,8 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	private int hungerStarveDelay; // The delay between each time the hunger bar decreases your health
 
 	public HashMap<PotionType, Integer> potioneffects; // The potion effects currently applied to the player
-	public boolean showpotioneffects; // Whether to display the current potion effects on screen
-	public boolean simpPotionEffects;
+	public boolean showPotionEffects; // Whether to display the current potion effects on screen
+	public boolean simplifyPotionEffects;
 	public boolean renderGUI;
 	public int questExpanding; // Lets the display keeps expanded.
 	private int cooldowninfo; // Prevents you from toggling the info pane on and off super fast.
@@ -186,8 +185,8 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		};
 
 		potioneffects = new HashMap<>();
-		showpotioneffects = true;
-		simpPotionEffects = false;
+		showPotionEffects = true;
+		simplifyPotionEffects = false;
 		renderGUI = true;
 
 		cooldowninfo = 0;
@@ -307,20 +306,20 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		if (cooldowninfo > 0) cooldowninfo--;
 		if (questExpanding > 0) questExpanding--;
 
-		if (input.inputPressed("potionEffects") && cooldowninfo == 0) {
+		if (input.inputPressed("POTION-EFFECTS") && cooldowninfo == 0) {
 			cooldowninfo = 10;
-			showpotioneffects = !showpotioneffects;
+			showPotionEffects = !showPotionEffects;
 		}
 
-		if (input.inputPressed("simpPotionEffects")) {
-			simpPotionEffects = !simpPotionEffects;
+		if (input.inputPressed("SIMPLIFY-POTION-EFFECTS")) {
+			simplifyPotionEffects = !simplifyPotionEffects;
 		}
 
-		if (input.inputPressed("toggleHUD")) {
+		if (input.inputPressed("TOGGLE-HUD")) {
 			renderGUI = !renderGUI;
 		}
 
-		if (input.inputPressed("expandQuestDisplay")) {
+		if (input.inputPressed("EXPAND-QUEST-DISPLAY")) {
 			questExpanding = 30;
 		}
 
@@ -527,9 +526,7 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 				if (input.inputPressed("craft") && !use())
 					Game.setDisplay(new CraftingDisplay(Recipes.craftRecipes, "minicraft.displays.crafting", this, true));
 
-				if (input.inputDown("info")) Game.setDisplay(new InfoDisplay());
-
-				if (input.inputDown("quicksave") && !Updater.saving) {
+				if (input.inputPressed("QUICK-SAVE") && !Updater.saving) {
 					Updater.saving = true;
 					LoadingDisplay.setPercentage(0);
 					new Save(WorldSelectDisplay.getWorldName());

--- a/src/client/java/minicraft/entity/mob/Sheep.java
+++ b/src/client/java/minicraft/entity/mob/Sheep.java
@@ -54,7 +54,7 @@ public class Sheep extends PassiveMob {
 		}
 	}
 
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean attack(Player player, @Nullable Item item, Direction attackDir) {
 		if (cut) return false;
 
 		if (item instanceof ToolItem) {

--- a/src/client/java/minicraft/item/FishingRodItem.java
+++ b/src/client/java/minicraft/item/FishingRodItem.java
@@ -68,10 +68,7 @@ public class FishingRodItem extends Item {
         return false;
     }
 
-    @Override
-    public boolean canAttack() { return false; }
-
-    @Override
+	@Override
     public boolean isDepleted() {
         if (random.nextInt(100) > 120 - uses + level * 6) { // Breaking is random, the lower the level, and the more times you use it, the higher the chance
             Game.notifications.add("Your Fishing rod broke.");

--- a/src/client/java/minicraft/item/FurnitureItem.java
+++ b/src/client/java/minicraft/item/FurnitureItem.java
@@ -70,12 +70,7 @@ public class FurnitureItem extends Item {
 		placed = false;
 	}
 
-	/** Determines if you can attack enemies with furniture (you can't) */
-	public boolean canAttack() {
-		return false;
-	}
-
-	/** What happens when you press the "Attack" key with the furniture in your hands */
+    /** What happens when you press the "Attack" key with the furniture in your hands */
 	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
 		if (tile.mayPass(level, xt, yt, furniture)) { // If the furniture can go on the tile
 			Sound.play("craft");

--- a/src/client/java/minicraft/item/Item.java
+++ b/src/client/java/minicraft/item/Item.java
@@ -37,6 +37,11 @@ public abstract class Item {
 		Font.drawBackground(dispName, screen, x + 8, y, fontColor);
 	}
 
+	/** Determines what happens when the player attacks with a tile */
+	public boolean attackOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+		return false;
+	}
+
 	/** Determines what happens when the player interacts with a tile */
 	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
 		return false;
@@ -44,11 +49,6 @@ public abstract class Item {
 
 	/** Returning true causes this item to be removed from the player's active item slot */
 	public boolean isDepleted() {
-		return false;
-	}
-
-	/** Returns if the item can attack mobs or not */
-	public boolean canAttack() {
 		return false;
 	}
 

--- a/src/client/java/minicraft/item/Item.java
+++ b/src/client/java/minicraft/item/Item.java
@@ -37,7 +37,7 @@ public abstract class Item {
 		Font.drawBackground(dispName, screen, x + 8, y, fontColor);
 	}
 
-	/** Determines what happens when the player attacks with a tile */
+	/** Determines what happens when the player attacks a tile */
 	public boolean attackOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
 		return false;
 	}

--- a/src/client/java/minicraft/item/ToolItem.java
+++ b/src/client/java/minicraft/item/ToolItem.java
@@ -2,10 +2,16 @@ package minicraft.item;
 
 import minicraft.core.Game;
 import minicraft.core.io.Localization;
+import minicraft.entity.Arrow;
+import minicraft.entity.Direction;
 import minicraft.entity.Entity;
 import minicraft.entity.mob.Mob;
+import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
+import minicraft.level.Level;
+import minicraft.level.tile.Tile;
+import minicraft.screen.AchievementsDisplay;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -71,9 +77,24 @@ public class ToolItem extends Item {
 		return dur <= 0 && type.durability > 0;
 	}
 
-	/** You can attack mobs with tools. */
-	public boolean canAttack() {
-		return type != ToolType.Shears;
+	@Override
+	public boolean interactsWithWorld() {
+		return type != ToolType.Bow;
+	}
+
+	@Override
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+		Inventory inventory = player.getInventory();
+		// Fire a bow if the player has the stamina and an arrow.
+		if (type == ToolType.Bow && player.payStamina(1) && inventory.count(Items.arrowItem) > 0) {
+			inventory.removeItem(Items.arrowItem);
+			level.add(new Arrow(player, attackDir, this.level));
+			if (!Game.isMode("minicraft.settings.mode.creative")) dur--;
+			AchievementsDisplay.setAchievement("minicraft.achievement.bow",true);
+			return true;
+		}
+
+		return super.interactOn(tile, level, xt, yt, player, attackDir);
 	}
 
 	public boolean payDurability() {

--- a/src/client/java/minicraft/level/tile/BossDoorTile.java
+++ b/src/client/java/minicraft/level/tile/BossDoorTile.java
@@ -18,7 +18,7 @@ public class BossDoorTile extends DoorTile {
 		super(Material.Obsidian, "Boss Door");
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
 			if (item instanceof ToolItem) {
 				ToolItem tool = (ToolItem) item;
@@ -34,7 +34,7 @@ public class BossDoorTile extends DoorTile {
 			return false;
 		}
 
-		return super.interact(level, xt, yt, player, item, attackDir);
+		return super.attack(level, xt, yt, player, item, attackDir);
 	}
 
 	@Override

--- a/src/client/java/minicraft/level/tile/BossDoorTile.java
+++ b/src/client/java/minicraft/level/tile/BossDoorTile.java
@@ -38,14 +38,12 @@ public class BossDoorTile extends DoorTile {
 	}
 
 	@Override
-	public boolean hurt(Level level, int x, int y, Mob source, int dmg, Direction attackDir) {
-		if (source instanceof Player) {
-			if (ObsidianKnight.active && !Game.isMode("minicraft.settings.mode.creative")) {
-				Game.notifications.add(doorMsg);
-				return true;
-			}
+	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+		if (ObsidianKnight.active && !Game.isMode("minicraft.settings.mode.creative")) {
+			Game.notifications.add(doorMsg);
+			return true;
 		}
 
-		return super.hurt(level, x, y, source, dmg, attackDir);
+		return super.interact(level, xt, yt, player, item, attackDir);
 	}
 }

--- a/src/client/java/minicraft/level/tile/BossFloorTile.java
+++ b/src/client/java/minicraft/level/tile/BossFloorTile.java
@@ -17,7 +17,7 @@ public class BossFloorTile extends FloorTile {
 		super(Material.Obsidian, "Boss Floor");
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
 			if (item instanceof ToolItem) {
 				ToolItem tool = (ToolItem) item;
@@ -33,6 +33,6 @@ public class BossFloorTile extends FloorTile {
 			return false;
 		}
 
-		return super.interact(level, xt, yt, player, item, attackDir);
+		return super.attack(level, xt, yt, player, item, attackDir);
 	}
 }

--- a/src/client/java/minicraft/level/tile/BossWallTile.java
+++ b/src/client/java/minicraft/level/tile/BossWallTile.java
@@ -23,7 +23,7 @@ public class BossWallTile extends WallTile {
 		sprite = obsidian; // Renewing the connectivity.
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
 			if (item instanceof ToolItem) {
 				ToolItem tool = (ToolItem) item;
@@ -39,6 +39,6 @@ public class BossWallTile extends WallTile {
 			return false;
 		}
 
-		return super.interact(level, xt, yt, player, item, attackDir);
+		return super.attack(level, xt, yt, player, item, attackDir);
 	}
 }

--- a/src/client/java/minicraft/level/tile/CloudTile.java
+++ b/src/client/java/minicraft/level/tile/CloudTile.java
@@ -26,7 +26,7 @@ public class CloudTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		// We don't want the tile to break when attacked with just anything, even in creative mode
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;

--- a/src/client/java/minicraft/level/tile/DecorTile.java
+++ b/src/client/java/minicraft/level/tile/DecorTile.java
@@ -25,7 +25,7 @@ public class DecorTile extends Tile {
 		maySpawn = true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == type.getRequiredTool()) {

--- a/src/client/java/minicraft/level/tile/DirtTile.java
+++ b/src/client/java/minicraft/level/tile/DirtTile.java
@@ -47,7 +47,7 @@ public class DirtTile extends Tile {
 		levelSprite[dIdx(level.depth)].render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/level/tile/DoorTile.java
+++ b/src/client/java/minicraft/level/tile/DoorTile.java
@@ -65,12 +65,10 @@ public class DoorTile extends Tile {
 		return false;
 	}
 
-	public boolean hurt(Level level, int x, int y, Mob source, int dmg, Direction attackDir) {
-		if (source instanceof Player) {
-			boolean closed = level.getData(x, y) == 0;
-			level.setData(x, y, closed ? 1 : 0);
-		}
-		return false;
+	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+		boolean closed = level.getData(xt, yt) == 0;
+		level.setData(xt, yt, closed ? 1 : 0);
+		return true;
 	}
 
 	public boolean mayPass(Level level, int x, int y, Entity e) {

--- a/src/client/java/minicraft/level/tile/DoorTile.java
+++ b/src/client/java/minicraft/level/tile/DoorTile.java
@@ -46,7 +46,7 @@ public class DoorTile extends Tile {
 		curSprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == type.getRequiredTool()) {

--- a/src/client/java/minicraft/level/tile/FloorTile.java
+++ b/src/client/java/minicraft/level/tile/FloorTile.java
@@ -27,7 +27,7 @@ public class FloorTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == type.getRequiredTool()) {

--- a/src/client/java/minicraft/level/tile/FlowerTile.java
+++ b/src/client/java/minicraft/level/tile/FlowerTile.java
@@ -47,7 +47,7 @@ public class FlowerTile extends Tile {
 		(shape == 0 ? flowerSprite0 : flowerSprite1).render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int x, int y, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int x, int y, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/level/tile/GrassTile.java
+++ b/src/client/java/minicraft/level/tile/GrassTile.java
@@ -46,7 +46,7 @@ public class GrassTile extends Tile {
 		sprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/level/tile/HardRockTile.java
+++ b/src/client/java/minicraft/level/tile/HardRockTile.java
@@ -38,7 +38,7 @@ public class HardRockTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if(Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
 		if (item instanceof ToolItem) {

--- a/src/client/java/minicraft/level/tile/LavaBrickTile.java
+++ b/src/client/java/minicraft/level/tile/LavaBrickTile.java
@@ -18,7 +18,7 @@ public class LavaBrickTile extends Tile {
 		super(name, new SpriteAnimation(SpriteType.Tile, "missing_tile"));
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Pickaxe) {

--- a/src/client/java/minicraft/level/tile/MaterialTile.java
+++ b/src/client/java/minicraft/level/tile/MaterialTile.java
@@ -26,7 +26,7 @@ public class MaterialTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == type.getRequiredTool()) {

--- a/src/client/java/minicraft/level/tile/OreTile.java
+++ b/src/client/java/minicraft/level/tile/OreTile.java
@@ -66,7 +66,7 @@ public class OreTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if(Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
 		if (item instanceof ToolItem) {

--- a/src/client/java/minicraft/level/tile/PathTile.java
+++ b/src/client/java/minicraft/level/tile/PathTile.java
@@ -21,7 +21,7 @@ public class PathTile extends Tile {
         maySpawn = true;
     }
 
-    public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+    public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
         if (item instanceof ToolItem) {
             ToolItem tool = (ToolItem) item;
             if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/level/tile/RockTile.java
+++ b/src/client/java/minicraft/level/tile/RockTile.java
@@ -51,7 +51,7 @@ public class RockTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Pickaxe && player.payStamina(5 - tool.level) && tool.payDurability()) {

--- a/src/client/java/minicraft/level/tile/SandTile.java
+++ b/src/client/java/minicraft/level/tile/SandTile.java
@@ -62,7 +62,7 @@ public class SandTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/level/tile/StairsTile.java
+++ b/src/client/java/minicraft/level/tile/StairsTile.java
@@ -37,8 +37,8 @@ public class StairsTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		super.interact(level, xt, yt, player, item, attackDir);
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+		super.attack(level, xt, yt, player, item, attackDir);
 
 		// Makes it so you can remove the stairs if you are in creative and debug mode.
 		if (item instanceof PowerGloveItem && Game.isMode("minicraft.settings.mode.creative")) {

--- a/src/client/java/minicraft/level/tile/Tile.java
+++ b/src/client/java/minicraft/level/tile/Tile.java
@@ -119,6 +119,20 @@ public abstract class Tile {
 	 * @param attackDir The direction of the player attacking.
 	 * @return Was the operation successful?
 	 */
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+		return false;
+	}
+
+	/**
+	 * Called when you interact an item on a tile (ex: Pickaxe on rock).
+	 * @param level The level the player is on.
+	 * @param xt X position of the player in tile coordinates (32x per tile).
+	 * @param yt Y position of the player in tile coordinates (32px per tile).
+	 * @param player The player who called this method.
+	 * @param item The item the player is currently holding.
+	 * @param attackDir The direction of the player attacking.
+	 * @return Was the operation successful?
+	 */
 	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		return false;
 	}

--- a/src/client/java/minicraft/level/tile/TorchTile.java
+++ b/src/client/java/minicraft/level/tile/TorchTile.java
@@ -47,7 +47,7 @@ public class TorchTile extends Tile {
 		return 5;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if(item instanceof PowerGloveItem) {
 			int data = level.getData(xt, yt);
 			level.setTile(xt, yt, this.onType);

--- a/src/client/java/minicraft/level/tile/TreeTile.java
+++ b/src/client/java/minicraft/level/tile/TreeTile.java
@@ -90,7 +90,7 @@ public class TreeTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if(Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
 		if (item instanceof ToolItem) {

--- a/src/client/java/minicraft/level/tile/WallTile.java
+++ b/src/client/java/minicraft/level/tile/WallTile.java
@@ -56,7 +56,7 @@ public class WallTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
 		if (item instanceof ToolItem) {

--- a/src/client/java/minicraft/level/tile/WoolTile.java
+++ b/src/client/java/minicraft/level/tile/WoolTile.java
@@ -19,7 +19,7 @@ public class WoolTile extends Tile {
 		super(woolType.name, woolType.sprite);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
 		if (item instanceof ToolItem) {
 			ToolItem tool = (ToolItem) item;
 			if (tool.type == ToolType.Shears) {

--- a/src/client/java/minicraft/level/tile/farming/FarmTile.java
+++ b/src/client/java/minicraft/level/tile/farming/FarmTile.java
@@ -26,7 +26,7 @@ public class FarmTile extends Tile {
     }
 
     @Override
-    public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+    public boolean attack(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
         if (item instanceof ToolItem) {
             ToolItem tool = (ToolItem) item;
             if (tool.type == ToolType.Shovel) {

--- a/src/client/java/minicraft/screen/BookDisplay.java
+++ b/src/client/java/minicraft/screen/BookDisplay.java
@@ -88,7 +88,7 @@ public class BookDisplay extends Display {
 
 	@Override
 	public void tick(InputHandler input) {
-		if (input.inputPressed("menu") || input.inputPressed("exit")) Game.exitDisplay(); // Close the menu.
+		if (input.inputPressed("INVENTORY") || input.inputPressed("exit")) Game.exitDisplay(); // Close the menu.
 		if (input.inputPressed("cursor-left")) turnPage(-1); // This is what turns the page back
 		if (input.inputPressed("cursor-right")) turnPage(1); // This is what turns the page forward
 	}

--- a/src/client/java/minicraft/screen/ContainerDisplay.java
+++ b/src/client/java/minicraft/screen/ContainerDisplay.java
@@ -20,7 +20,7 @@ public class ContainerDisplay extends Display {
 
 	public ContainerDisplay(Player player, Chest chest) {
 		super(
-			new InventoryMenu(player, player.getInventory(), "minicraft.display.menus.inventory", RelPos.LEFT), 
+			new InventoryMenu(player, player.getInventory(), "minicraft.display.menus.inventory", RelPos.LEFT),
 			new InventoryMenu(chest, chest.getInventory(), chest.name, RelPos.RIGHT)
 		);
 
@@ -44,14 +44,14 @@ public class ContainerDisplay extends Display {
 	@Override
 	protected void onSelectionChange(int oldSel, int newSel) {
 		super.onSelectionChange(oldSel, newSel);
-		
+
 		if (oldSel == newSel) return; // this also serves as a protection against access to menus[0] when such may not exist.
-		
+
 		int shift = 0;
-		
+
 		if (newSel == 0) shift = padding - menus[0].getBounds().getLeft();
 		if (newSel == 1) shift = (Screen.w - padding) - menus[1].getBounds().getRight();
-		
+
 		for (Menu m: menus) {
 			m.translate(shift, 0);
 		}
@@ -77,7 +77,7 @@ public class ContainerDisplay extends Display {
 		if (onScreenKeyboardMenu == null || !curMenu.isSearcherBarActive() && !onScreenKeyboardMenu.isVisible()) {
 			super.tick(input);
 
-			if (input.inputPressed("menu") || chest.isRemoved()) {
+			if (input.inputPressed("INVENTORY") || chest.isRemoved()) {
 				Game.setDisplay(null);
 				return;
 			}
@@ -95,7 +95,7 @@ public class ContainerDisplay extends Display {
 			if (!acted)
 				curMenu.tick(input);
 
-			if (input.getKey("menu").clicked || chest.isRemoved()) {
+			if (input.inputPressed("INVENTORY") || input.inputPressed("EXIT") || chest.isRemoved()) {
 				Game.setDisplay(null);
 				return;
 			}

--- a/src/client/java/minicraft/screen/CraftingDisplay.java
+++ b/src/client/java/minicraft/screen/CraftingDisplay.java
@@ -117,7 +117,7 @@ public class CraftingDisplay extends Display {
 		boolean mainMethod = false;
 
 		if (onScreenKeyboardMenu == null || !recipeMenu.isSearcherBarActive() && !onScreenKeyboardMenu.isVisible()) {
-			if (input.inputPressed("menu") || (isPersonalCrafter && input.inputPressed("craft"))) {
+			if (input.inputPressed("INVENTORY") || (isPersonalCrafter && input.inputPressed("craft"))) {
 				Game.exitDisplay();
 				return;
 			}
@@ -134,7 +134,7 @@ public class CraftingDisplay extends Display {
 			if (!acted)
 				recipeMenu.tick(input);
 
-			if (input.getKey("menu").clicked || (isPersonalCrafter && input.inputPressed("craft"))) {
+			if (input.inputPressed("INVENTORY") || input.inputPressed("EXIT") || (isPersonalCrafter && input.inputPressed("craft"))) {
 				Game.exitDisplay();
 				return;
 			}

--- a/src/client/java/minicraft/screen/PauseDisplay.java
+++ b/src/client/java/minicraft/screen/PauseDisplay.java
@@ -24,7 +24,8 @@ public class PauseDisplay extends Display {
 				new BlankEntry(),
 				new SelectEntry("minicraft.displays.pause.return", () -> Game.setDisplay(null)),
 				new SelectEntry("minicraft.display.options_display", () -> Game.setDisplay(new OptionsWorldDisplay())),
-				new SelectEntry("minicraft.displays.achievements", () -> Game.setDisplay(new AchievementsDisplay()))
+				new SelectEntry("minicraft.displays.achievements", () -> Game.setDisplay(new AchievementsDisplay())),
+				new SelectEntry("minicraft.displays.info.title", () -> Game.setDisplay(new InfoDisplay()))
 		));
 
 		if (TutorialDisplayHandler.inQuests())

--- a/src/client/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerInvDisplay.java
@@ -82,7 +82,7 @@ public class PlayerInvDisplay extends Display {
 		if (onScreenKeyboardMenu == null || !curMenu.isSearcherBarActive() && !onScreenKeyboardMenu.isVisible()) {
 			super.tick(input);
 
-			if (input.inputPressed("menu")) {
+			if (input.inputPressed("INVENTORY")) {
 				Game.exitDisplay();
 				return;
 			}
@@ -100,7 +100,7 @@ public class PlayerInvDisplay extends Display {
 			if (!acted)
 				curMenu.tick(input);
 
-			if (input.getKey("menu").clicked) { // Should not listen button press.
+			if (input.inputPressed("INVENTORY") || input.inputPressed("EXIT")) { // Should not listen button press.
 				Game.exitDisplay();
 				return;
 			}

--- a/src/client/java/minicraft/screen/TutorialDisplayHandler.java
+++ b/src/client/java/minicraft/screen/TutorialDisplayHandler.java
@@ -171,7 +171,7 @@ public class TutorialDisplayHandler {
 	public static void tick(InputHandler input) {
 		if (currentGuide != null) {
 			if (ControlGuide.animation > 0) ControlGuide.animation--;
-			if (input.getKey("expandQuestDisplay").clicked) {
+			if (input.getKey("EXPAND-QUEST-DISPLAY").clicked) {
 				Logging.TUTORIAL.debug("Force-completed the guides.");
 				turnOffGuides();
 				return;
@@ -192,7 +192,7 @@ public class TutorialDisplayHandler {
 		}
 
 		if (currentOngoingElement != null) {
-			if (input.getKey("expandQuestDisplay").clicked && Game.getDisplay() == null) {
+			if (input.getKey("EXPAND-QUEST-DISPLAY").clicked && Game.getDisplay() == null) {
 				Game.setDisplay(new PopupDisplay(new PopupDisplay.PopupConfig(currentOngoingElement.key, null, 4),
 					currentOngoingElement.description));
 			}
@@ -244,7 +244,7 @@ public class TutorialDisplayHandler {
 			menu.render(screen);
 			Rectangle bounds = menu.getBounds();
 			String text = Localization.getLocalized("minicraft.displays.tutorial_display_handler.display.element_examine_help",
-				Game.input.getMapping("expandQuestDisplay"));
+				Game.input.getMapping("EXPAND-QUEST-DISPLAY"));
 			String[] lines = Font.getLines(text, Screen.w*2/3, Screen.h, 0);
 			for (int i = 0; i < lines.length; i++)
 				Font.draw(lines[i], screen, bounds.getRight() - Font.textWidth(lines[i]), bounds.getBottom() + 8 * (1+i), Color.GRAY);

--- a/src/client/java/minicraft/screen/TutorialDisplayHandler.java
+++ b/src/client/java/minicraft/screen/TutorialDisplayHandler.java
@@ -69,8 +69,8 @@ public class TutorialDisplayHandler {
 					Game.input.getMapping("move-right")))));
 		controlGuides.add(new ControlGuide(1, "attack",
 			() -> Localization.getLocalized("minicraft.control_guide.attack", Game.input.getMapping("attack"))));
-		controlGuides.add(new ControlGuide(1, "menu",
-			() -> Localization.getLocalized("minicraft.control_guide.menu", Game.input.getMapping("menu"))));
+		controlGuides.add(new ControlGuide(1, "inventory",
+			() -> Localization.getLocalized("minicraft.control_guide.menu", Game.input.getMapping("INVENTORY"))));
 		controlGuides.add(new ControlGuide(1, "craft",
 			() -> Localization.getLocalized("minicraft.control_guide.craft", Game.input.getMapping("craft"))));
 	}


### PR DESCRIPTION
Resolves #435
Many of the methods combine attack and interact when handling interactions and damage dealing, causing the combination complexity. This adds key bindings of "interact" and "inventory" to replace the original "menu" and some implementations from "attack". Originally: "attack" - `C|SPACE|ENTER`, "menu" - `X|E`' currently: "attack" - `C|SPACE`, "interact" - `X|ENTER`, `inventory` - `E`. "Inventory" now only opens player inventory menus or closes some in-game menus; "attack" now only handles direct damage and tile destroy with bare hand or any item on tiles or entities; "interact" is now for interacting with furniture, placing tile and furniture, item interactions, etc.