### PR TITLE
Make PotionItem and ClothingItem not return consumed item when used in creative mode

### DIFF
--- a/src/client/java/minicraft/item/ClothingItem.java
+++ b/src/client/java/minicraft/item/ClothingItem.java
@@ -1,5 +1,6 @@
 package minicraft.item;
 
+import minicraft.core.Game;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Color;
@@ -42,13 +43,15 @@ public class ClothingItem extends StackableItem {
 		if (player.shirtColor == playerCol) {
 			return false;
 		} else {
-			ClothingItem lastClothing = (ClothingItem) getAllInstances().stream().filter(i -> i instanceof ClothingItem && ((ClothingItem) i).playerCol == player.shirtColor)
-				.findAny().orElse(null);
-			if (lastClothing == null)
-				lastClothing = (ClothingItem) Items.get("Reg Clothes");
-			lastClothing = lastClothing.copy();
-			lastClothing.count = 1;
-			player.tryAddToInvOrDrop(lastClothing);
+			if (!Game.isMode("minicraft.settings.mode.creative")) {
+				ClothingItem lastClothing = (ClothingItem) getAllInstances().stream().filter(i -> i instanceof ClothingItem && ((ClothingItem) i).playerCol == player.shirtColor)
+					.findAny().orElse(null);
+				if (lastClothing == null)
+					lastClothing = (ClothingItem) Items.get("Reg Clothes");
+				lastClothing = lastClothing.copy();
+				lastClothing.count = 1;
+				player.tryAddToInvOrDrop(lastClothing);
+			}
 			player.shirtColor = playerCol;
 			return super.interactOn(true);
 		}

--- a/src/client/java/minicraft/item/PotionItem.java
+++ b/src/client/java/minicraft/item/PotionItem.java
@@ -1,5 +1,6 @@
 package minicraft.item;
 
+import minicraft.core.Game;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
@@ -39,7 +40,7 @@ public class PotionItem extends StackableItem {
 	}
 
 	protected boolean interactOn(boolean subClassSuccess, Player player) {
-		if (subClassSuccess)
+		if (subClassSuccess && !Game.isMode("minicraft.settings.mode.creative"))
 			player.tryAddToInvOrDrop(Items.get("glass bottle"));
 		return super.interactOn(subClassSuccess);
 	}


### PR DESCRIPTION
As described, as these two items should not return item in creative mode, they now do not return empty glass bottle and previous clothing item when used in creative mode.