### PR TITLE
Change numeric entity IDs into UUIDs

### DIFF
--- a/src/client/java/minicraft/core/Game.java
+++ b/src/client/java/minicraft/core/Game.java
@@ -4,7 +4,6 @@ import minicraft.core.io.InputHandler;
 import minicraft.core.io.Settings;
 import minicraft.core.io.Sound;
 import minicraft.entity.mob.Player;
-import minicraft.gfx.Screen;
 import minicraft.level.Level;
 import minicraft.level.tile.Tiles;
 import minicraft.network.Analytics;
@@ -19,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class Game {
 	protected Game() {} // Can't instantiate the Game class.
@@ -102,7 +102,7 @@ public class Game {
 		Renderer.initScreen();
 
 		World.resetGame(); // "half"-starts a new game, to set up initial variables
-		player.eid = 0;
+		player.uuid = UUID.randomUUID();
 		new Load(true); // This loads any saved preferences.
 		MAX_FPS = (int) Settings.get("fps"); // DO NOT put this above.
 

--- a/src/client/java/minicraft/entity/Arrow.java
+++ b/src/client/java/minicraft/entity/Arrow.java
@@ -49,7 +49,7 @@ public class Arrow extends Entity implements ClientTickable {
 	 * @return string representation of owner, xdir, ydir and damage.
 	 */
 	public String getData() {
-		return owner.eid + ":" + dir.ordinal() + ":"+damage;
+		return owner.uuid + ":" + dir.ordinal() + ":"+damage;
 	}
 
 	@Override

--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.function.IntSupplier;
 
 public abstract class Entity implements Tickable {
@@ -39,7 +40,7 @@ public abstract class Entity implements Tickable {
 	public int col; // Current color.
 
 	// Numeric unique identifier for the entity.
-	public int eid;
+	public UUID uuid;
 
 	/**
 	 * Default constructor for the Entity class.
@@ -57,7 +58,7 @@ public abstract class Entity implements Tickable {
 		removed = true;
 		col = 0;
 
-		eid = -1;
+		uuid = null;
 	}
 
 	public abstract void render(Screen screen); // Used to render the entity on screen.
@@ -262,8 +263,8 @@ public abstract class Entity implements Tickable {
 		this.x = x;
 		this.y = y;
 
-		if (eid < 0)
-			eid = Network.generateUniqueEntityId();
+		if (uuid == null)
+			uuid = Network.generateUniqueEntityUUID();
 	}
 
 	public boolean isWithin(int tileRadius, Entity other) {
@@ -301,7 +302,7 @@ public abstract class Entity implements Tickable {
 	public String toString() { return getClass().getSimpleName() + getDataPrints(); }
 	protected List<String> getDataPrints() {
 		List<String> prints = new ArrayList<>();
-		prints.add("eid=" + eid);
+		prints.add("UUID=" + uuid);
 		return prints;
 	}
 
@@ -311,5 +312,5 @@ public abstract class Entity implements Tickable {
 	}
 
 	@Override
-	public final int hashCode() { return eid; }
+	public final int hashCode() { return uuid.hashCode(); }
 }

--- a/src/client/java/minicraft/entity/FireSpark.java
+++ b/src/client/java/minicraft/entity/FireSpark.java
@@ -105,6 +105,6 @@ public class FireSpark extends Entity {
 	 * @return the owners id as a string.
 	 */
 	public String getData() {
-		return owner.eid + "";
+		return owner.uuid + "";
 	}
 }

--- a/src/client/java/minicraft/entity/Spark.java
+++ b/src/client/java/minicraft/entity/Spark.java
@@ -86,6 +86,6 @@ public class Spark extends Entity {
 	 * @return the owners id as a string.
 	 */
 	public String getData() {
-		return owner.eid + "";
+		return owner.uuid + "";
 	}
 }

--- a/src/client/java/minicraft/network/Network.java
+++ b/src/client/java/minicraft/network/Network.java
@@ -13,12 +13,10 @@ import minicraft.util.Logging;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 
-import java.util.Random;
+import java.util.UUID;
 
 public class Network extends Game {
 	private Network() {}
-
-	private static final Random random = new Random();
 
 	private static VersionInfo latestVersion = null;
 
@@ -48,39 +46,38 @@ public class Network extends Game {
 	}
 
 	@Nullable
-	public static Entity getEntity(int eid) {
+	public static Entity getEntity(UUID uuid) {
 		for (Level level: levels) {
 			if (level == null) continue;
 			for (Entity e: level.getEntityArray())
-				if (e.eid == eid)
+				if (e.uuid.equals(uuid))
 					return e;
 		}
 
 		return null;
 	}
 
-	public static int generateUniqueEntityId() {
-		int eid;
+	public static UUID generateUniqueEntityUUID() {
+		UUID uuid;
 		int tries = 0; // Just in case it gets out of hand.
 		do {
 			tries++;
 			if (tries == 1000)
 				Logging.NETWORK.info("Note: Trying 1000th time to find valid entity id...(Will continue)");
 
-			eid = random.nextInt();
-		} while (!idIsAvailable(eid));
+			uuid = UUID.randomUUID();
+		} while (!idIsAvailable(uuid));
 
-		return eid;
+		return uuid;
 	}
 
-	public static boolean idIsAvailable(int eid) {
-		if (eid == 0) return false; // This is reserved for the main player... kind of...
-		if (eid < 0) return false; // ID's must be positive numbers.
+	public static boolean idIsAvailable(UUID uuid) { // May use a stored UUID set
+		if (uuid == null) return false; // Invalid
 
 		for (Level level: levels) {
 			if (level == null) continue;
 			for (Entity e: level.getEntityArray()) {
-				if (e.eid == eid)
+				if (e.uuid.equals(uuid))
 					return false;
 			}
 		}

--- a/src/client/java/minicraft/saveload/Save.java
+++ b/src/client/java/minicraft/saveload/Save.java
@@ -354,7 +354,7 @@ public class Save {
 			return "";
 
 		if (!isLocalSave)
-			extradata.append(":").append(e.eid);
+			extradata.append(":").append(e.uuid);
 
 		if (e instanceof Mob) {
 			Mob m = (Mob)e;


### PR DESCRIPTION
For compatibility in the near future, increasing the bounds of the IDs would be necessary. A UUID can have 2^128 possible values while an integral ID can have 2^32 possible values. Also, the conversion between the string value and the instance is well-defined in UUID. Old EIDs are recorded in world load entity mapping, so that the old IDs can correspond to the entities whilst new UUIDs are generated.
If there is an account system in the future, the system would also use UUIDs for identifiers, and the player instances would use these UUIDs as their entity identifiers. Note that UUIDs should be used as the IDs for instances (especially these related to entities and players) in common for security.
It is also noticed that some entities cannot be loaded before some entities being loaded, so this problem might be potentially valid and should be resolved in the near future.