### PR TITLE
Remove the removal for empty values in saves

### DIFF
--- a/src/client/java/minicraft/saveload/Load.java
+++ b/src/client/java/minicraft/saveload/Load.java
@@ -315,7 +315,7 @@ public class Load {
 			if (ch == commaChar && bracketCounter.isEmpty()) {
 				String str = input.substring(lastIdx + (input.charAt(lastIdx) == commaChar ? 1 : 0), i).trim();
 				lastIdx = i;
-				if (!str.isEmpty()) out.add(str);
+				out.add(str); // Empty strings are expected.
 			} else if (ch == openBracket0) {
 				bracketCounter.push(0);
 			} else if (ch == closeBracket0) {


### PR DESCRIPTION
This would fix #564.
This is a further fix for #519. As the preferences may contain empty values, if the preferences contain empty values, unexpected errors may occur due to the original design based on values "as is" (without empty string removals).
Bypassing this problem in 2.2.0-dev3, users can first launch versions before 2.2.0-dev3 to generate JSON format preferences without this kind of error (as mentioned in https://github.com/MinicraftPlus/minicraft-plus-revived/pull/519#issuecomment-1694990750).

Note that if players have already been using 2.2.0-dev3 or 2.2.0-dev2 updating their preferences, the preferences settings might have already been broken.