### PR TITLE
Fix mobs spawning

### DIFF
--- a/src/client/java/minicraft/entity/mob/Mob.java
+++ b/src/client/java/minicraft/entity/mob/Mob.java
@@ -129,12 +129,12 @@ public abstract class Mob extends Entity {
 
 	/** The mob immediately despawns if the distance of the closest player is greater than the return value of this. */
 	protected int getDespawnDistance() {
-		return 80;
+		return 1280;
 	}
 
 	/** The mob randomly despawns if the distance of the closest player is greater than the return value of this. */
 	protected int getNoDespawnDistance() {
-		return 40;
+		return 640;
 	}
 
 	/** @see #handleDespawn() */

--- a/src/client/java/minicraft/entity/mob/MobAi.java
+++ b/src/client/java/minicraft/entity/mob/MobAi.java
@@ -66,7 +66,10 @@ public abstract class MobAi extends Mob {
 	 */
 	protected boolean isWithinLight() {
 		return Arrays.stream(level.getEntityArray()).anyMatch(e -> e instanceof Lantern && isWithin(e.getLightRadius(), e))
-			|| !level.getMatchingTiles((tile, x, y) -> Math.hypot(Math.abs(this.x - x), Math.abs(this.y - y)) <= tile.getLightRadius(level, x, y)).isEmpty();
+			|| !level.getMatchingTiles((tile, x, y) -> {
+				int xx = Math.abs(this.x - x), yy = Math.abs(this.y - y), l = tile.getLightRadius(level, x, y);
+				return xx * xx + yy * yy <= l * l;
+		}).isEmpty();
 	}
 
 	/**

--- a/src/client/java/minicraft/level/Level.java
+++ b/src/client/java/minicraft/level/Level.java
@@ -571,12 +571,13 @@ public class Level {
 
 		boolean spawned = false;
 		for (Player player : players) {
+			assert player.getLevel().depth == depth;
 			int lvl = World.lvlIdx(player.getLevel().depth);
 			for (int i = 0; i < 30 && !spawned; i++) {
 				int rnd = random.nextInt(100);
 				int nx = random.nextInt(w) * 16 + 8, ny = random.nextInt(h) * 16 + 8;
 				double distance = Math.hypot(Math.abs(nx - player.x), Math.abs(ny - player.y));
-				if (distance < 10 || distance > 40) continue; // Spawns only between 10 and 40 tiles far from players.
+				if (distance < 160) continue; // Spawns only far from 10 tiles away.
 
 				//System.out.println("trySpawn on level " + depth + " of lvl " + lvl + " mob w/ rand " + rnd + " at tile " + nx + "," + ny);
 


### PR DESCRIPTION
This fixes that mobs cannot be normally spawned because of the misconfigurations. The main reason is that the values are set as the tile distances for entity despawn distances. A use of using `Math#hypot` is prevented to speed up the calculation.