### PR TITLE
Fix wrong enemy level in mob generation

### DIFF
--- a/src/client/java/minicraft/level/Level.java
+++ b/src/client/java/minicraft/level/Level.java
@@ -35,6 +35,7 @@ import minicraft.level.tile.Tiles;
 import minicraft.level.tile.TorchTile;
 import minicraft.level.tile.TreeTile;
 import minicraft.util.Logging;
+import minicraft.util.MyUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -607,7 +608,7 @@ public class Level {
 		boolean spawned = false;
 		for (Player player : players) {
 			assert player.getLevel().depth == depth;
-			int lvl = World.lvlIdx(player.getLevel().depth);
+			int lvl = -MyUtils.clamp(player.getLevel().depth, -4, 0);
 			for (int i = 0; i < 30 && !spawned; i++) {
 				int rnd = random.nextInt(100);
 				int nx = random.nextInt(w) * 16 + 8, ny = random.nextInt(h) * 16 + 8;


### PR DESCRIPTION
As spotted out by @Litorom, there is an exception regarding the enemy level.
```
Unhandled error: General Application Crash
java.lang.ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4
    at minicraft.entity.mob.EnemyMob.render(EnemyMob.java:106)
    at minicraft.level.Level.sortAndRender(Level.java:536)
    at minicraft.level.Level.renderSprites(Level.java:499)
    at minicraft.core.Renderer.renderLevel(Renderer.java:209)
    at minicraft.core.Renderer.render(Renderer.java:119)
    at minicraft.core.Initializer.run(Initializer.java:100)
    at minicraft.core.Game.main(Game.java:116)
```occurred in the dungeon level.

This is related to the wrong code getting the level. In the current code, the depth number is mapped to level index ranged from 0 to the number of levels-1, but the enemy level only supports range from 0 to 4. Originally, -1 should be mapped to 1 and etc. Now, it is fixed so that depths with 1 and 0 mapped to 0 and -n mapped to n, where n ∈ {1,2,3,4}.