### PR TITLE
Resolve any potential NullPointerException throws caused by Entity#getClosestPlayer()

### DIFF
--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -376,6 +376,7 @@ public abstract class Entity implements Tickable {
 	 *
 	 * @return the closest player.
 	 */
+	@Nullable
 	protected Player getClosestPlayer() {
 		return getClosestPlayer(true);
 	}
@@ -387,6 +388,7 @@ public abstract class Entity implements Tickable {
 	 * @param returnSelf determines if the method can return itself.
 	 * @return The closest player to this entity.
 	 */
+	@Nullable
 	protected Player getClosestPlayer(boolean returnSelf) {
 		if (this instanceof Player && returnSelf)
 			return (Player) this;

--- a/src/client/java/minicraft/entity/Spark.java
+++ b/src/client/java/minicraft/entity/Spark.java
@@ -51,7 +51,7 @@ public class Spark extends Entity {
 		y = (int) yy;
 
 		Player player = getClosestPlayer();
-		if (player.isWithin(0, this)) {
+		if (player != null && player.isWithin(0, this)) {
 			player.hurt(owner, 1);
 		}
 	}

--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -74,11 +74,13 @@ public class ObsidianKnight extends EnemyMob {
 	@Override
 	public void tick() {
 		super.tick();
-		if (getClosestPlayer().isRemoved()) {
+		Player player = getClosestPlayer();
+		if (player == null || player.isRemoved()) {
 			active = false;
 			KnightStatue ks = new KnightStatue(health);
 			level.add(ks, x, y, false);
 			this.remove();
+			return;
 		}
 
 		// Achieve phase 2
@@ -101,7 +103,6 @@ public class ObsidianKnight extends EnemyMob {
 		}
 
 		if (attackPhase == AttackPhase.Attacking) {
-			Player player = getClosestPlayer();
 			if (attackDelay > 0) {
 				xmov = ymov = 0;
 				int dir = (attackDelay - 35) / 4 % 4; // The direction of attack.


### PR DESCRIPTION
Resolves #602
A `NullPointerException` would be thrown as there are missing null handles.
This kind of potential bugs would be reduced by the time #512 is finished.

Known ways to reproduce:
- Player dies when there is a spark exists (can be generated by AirWizard) (? to 2.2.0-dev4)
- Player dies when Obsidian Knight is active. (Unchecked) (2.2.0-dev3 to 2.2.0-dev4)