### PR TITLE
Fixed Tnt interaction

### DIFF
--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -125,10 +125,16 @@ public class Tnt extends Furniture implements ActionListener {
 
 	@Override
 	public boolean interact(Player player, Item heldItem, Direction attackDir) {
-		if (!fuseLit) {
-			fuseLit = true;
-			Sound.play("fuse");
-			return true;
+		if (player.activeItem instanceof PowerGloveItem) {
+			if (!fuseLit) {
+				return super.interact(player, item, attackDir);
+			}
+		} else {
+			if (!fuseLit) {
+				fuseLit = true;
+				Sound.play("fuse");
+				return true;
+			}
 		}
 
 		return false;

--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -125,9 +125,9 @@ public class Tnt extends Furniture implements ActionListener {
 
 	@Override
 	public boolean interact(Player player, Item heldItem, Direction attackDir) {
-		if (player.activeItem instanceof PowerGloveItem) {
+		if (heldItem instanceof PowerGloveItem) {
 			if (!fuseLit) {
-				return super.interact(player, item, attackDir);
+				return super.interact(player, heldItem, attackDir);
 			}
 		} else {
 			if (!fuseLit) {

--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -11,6 +11,7 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.item.Item;
+import minicraft.item.PowerGloveItem;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 import minicraft.level.tile.Tiles;


### PR DESCRIPTION
_This bug seems to have been present for too long_

- Previously, when a player tried to pick up the placed Tnt to put it in their inventory, they could not do so and it would activate and explode accidentally, this because we did not handle that case within the appropriate method

- The player can now collect TNT again as long as it has not been previously activated


