### PR TITLE
Rate limit for autobuild.yml

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,11 +1,34 @@
 name: Nightly build
 on:
+  pull_request:
+    types: [closed]
+    branches: ["main"]
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
   
 jobs:
+  conditions:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checking conditions
+      run: |
+        needed=true
+        
+        out=$( gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/actions/workflows/${{ github.workflow }}/runs \
+          -F "created=>$( date -d '-1 day' '+%Y-%m-%d' )T00:00:00+00:00" )
+        $out | jq -c ".workflow_runs.[] | .status" | while read object; do
+          if [ "$object" = "completed" ] || [ "$object" = "success" ] || [ "$object" = "in_progress" ] ||
+            [ "$object" = "queued" ] || [ "$object" = "requested" ] || [ "$object" = "waiting" ] || [ "$object" = "pending" ]; then
+            needed=false; fi
+        done
+        if needed; then
   gradle:
+    needs: conditions
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -14,21 +14,11 @@ jobs:
     - name: Checking conditions
       run: |
         needed=true
-        out=$( gh api -XGET \
+        out=$( gh api \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          repos/${{ github.repository }}/pulls \
-          -F state=closed \
-          -F base=main \
-          -F sort=updated )
-        latest=
-        while read obj; do
-          if [[ $obj != null ]]; then
-            latest=$obj
-            break
-          fi
-        done < <( echo $out | jq -c -r ".[] | .merged_at" | tr -d "\r" )
-        [[ -z $latest ]] && echo "CONT=false" >> $GITHUB_ENV && exit 0
+          repos/${{ github.repository }}/commits )
+        latest=$( echo $out | jq -r "[.[] | select(.committer.login != \"github-actions[bot]\")] | .[0].commit.committer.date" )
         out=$( gh api -XGET \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -4,29 +4,57 @@ on:
     types: [closed]
     branches: ["main"]
   schedule:
-    - cron:  '0 0 * * *'
+    - cron:  '0 0,4,8,12,16,20 * * *'
   workflow_dispatch:
-  
+
 jobs:
   conditions:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Checking conditions
       run: |
         needed=true
-        
-        out=$( gh api \
+        out=$( gh api -XGET \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/${{ github.repository }}/actions/workflows/${{ github.workflow }}/runs \
-          -F "created=>$( date -d '-1 day' '+%Y-%m-%d' )T00:00:00+00:00" )
-        $out | jq -c ".workflow_runs.[] | .status" | while read object; do
-          if [ "$object" = "completed" ] || [ "$object" = "success" ] || [ "$object" = "in_progress" ] ||
-            [ "$object" = "queued" ] || [ "$object" = "requested" ] || [ "$object" = "waiting" ] || [ "$object" = "pending" ]; then
-            needed=false; fi
-        done
+          repos/${{ github.repository }}/pulls \
+          -F state=closed \
+          -F base=main \
+          -F sort=updated )
+        latest=
+        while read obj; do
+          if [[ $obj != null ]]; then
+            latest=$obj
+            break
+          fi
+        done < <( echo $out | jq -c -r ".[] | .merged_at" | tr -d "\r" )
+        [[ -z $latest ]] && echo "CONT=false" >> $GITHUB_ENV && exit 0
+        out=$( gh api -XGET \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          repos/${{ github.repository }}/actions/workflows/autobuild.yml/runs \
+          -F created=">=$latest" )
+        f="[\"completed\",\"success\",\"in_progress\",\"queued\",\"requested\",\"waiting\",\"pending\"]"
+        while read obj; do
+          if $obj; then
+            needed=false;
+            break;
+          fi
+        done < <( echo $out | jq -c --arg f "$f" ".workflow_runs.[] | .status | IN($f[])" | tr -d "\r" )
         if needed; then
+          echo "CONT=true" >> $GITHUB_ENV
+        else
+          echo "CONT=false" >> $GITHUB_ENV
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Abort
+      if: ${{ ! env.CONT }}
+      run: |
+        gh run cancel ${{ github.run_id }}
+        gh run watch ${{ github.run_id }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   gradle:
     needs: conditions
     strategy:


### PR DESCRIPTION
Now this workflow should now be able to run only when there is no successful or running auto build job since the latest commit not committed by Actions. This runs every time a pull request closed, manually or every 4 hours. A check is done before running. Within the check, it first fetches the commit datetime of the latest commit not committed by Actions (number of items: 30); then it searches for the presence of any successful or running or pending workflow runs (number of items: 30); it sends the boolean value to the environment about to continue the job or not, it is true if the presence is false; if the sent value is false, it aborts (cancels the workflow run). The build job requires conditions to run first, so that it will run only when conditions are successful.