### PR TITLE
Handle old folder copying destination file not having folder

### DIFF
--- a/src/client/java/minicraft/core/io/FileHandler.java
+++ b/src/client/java/minicraft/core/io/FileHandler.java
@@ -140,6 +140,7 @@ public class FileHandler extends Game {
 				}
 
 				Path newFile = new File(newFilename).toPath();
+				newFile.getParent().toFile().mkdirs();
 				try {
 					Files.copy(file, newFile, StandardCopyOption.REPLACE_EXISTING);
 				} catch (IOException ex) {


### PR DESCRIPTION
This resolves `NoSuchFileException` that occurs when moving old data folder contents to the new destination. This is because copying does not create new directory.