### PR TITLE
Tweak iron and gold recipe cost down to 3 ores

### DIFF
--- a/src/client/java/minicraft/item/Recipes.java
+++ b/src/client/java/minicraft/item/Recipes.java
@@ -111,8 +111,8 @@ public class Recipes {
 		anvilRecipes.add(new Recipe("Shears_1", "Iron_4"));
 		anvilRecipes.add(new Recipe("Watering Can_1", "Iron_3"));
 
-		furnaceRecipes.add(new Recipe("iron_1", "iron Ore_4", "coal_1"));
-		furnaceRecipes.add(new Recipe("gold_1", "gold Ore_4", "coal_1"));
+		furnaceRecipes.add(new Recipe("iron_1", "iron Ore_3", "coal_1"));
+		furnaceRecipes.add(new Recipe("gold_1", "gold Ore_3", "coal_1"));
 		furnaceRecipes.add(new Recipe("glass_1", "sand_4", "coal_1"));
 		furnaceRecipes.add(new Recipe("glass bottle_1", "glass_3"));
 


### PR DESCRIPTION
There is a view that both iron and gold are quite expensive if it costs 4 ores, so they are tweaked down to 3 ores.