### PR TITLE
Fix book item NullPointerException

### DIFF
--- a/src/client/java/minicraft/item/BookItem.java
+++ b/src/client/java/minicraft/item/BookItem.java
@@ -1,6 +1,7 @@
 package minicraft.item;
 
 import minicraft.core.Game;
+import minicraft.core.io.Localization;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
@@ -17,7 +18,7 @@ public class BookItem extends Item {
 
 	protected static ArrayList<Item> getAllInstances() {
 		ArrayList<Item> items = new ArrayList<Item>();
-		items.add(new BookItem("Book", new LinkedSprite(SpriteType.Item, "book"), null));
+		items.add(new BookItem("Book", new LinkedSprite(SpriteType.Item, "book"), () -> Localization.getLocalized("minicraft.displays.book.default_book")));
 		items.add(new BookItem("Antidious", new LinkedSprite(SpriteType.Item, "antidious_book"), () -> BookData.antVenomBook.collect(), true));
 		return items;
 	}


### PR DESCRIPTION
A `NullPointerException` occurred when interacted because the book content of the default book item has been set to `null`. The change was made by the resource pack update but later not updated correspondingly. This fixes this issue and set the book content back to the default empty one.