### PR TITLE
Fixed unlocked iron and gold recipes not matching actual recipe

### DIFF
--- a/src/client/resources/resources/recipes.json
+++ b/src/client/resources/resources/recipes.json
@@ -3333,7 +3333,7 @@
     "rewards": {
       "recipes": {
         "iron_1": [
-          "iron Ore_4",
+          "iron Ore_3",
           "coal_1"
         ]
       }
@@ -3375,7 +3375,7 @@
     "rewards": {
       "recipes": {
         "gold_1": [
-          "gold Ore_4",
+          "gold Ore_3",
           "coal_1"
         ]
       }


### PR DESCRIPTION
Right now, players do not have access to the correct iron and gold bar recipes in the furnace. Updated "resources/recipes.json" to reflect new furnace recipes.