### PR TITLE
Skip changed iron and gold recipes in world loading

### DIFF
--- a/src/client/java/minicraft/saveload/Load.java
+++ b/src/client/java/minicraft/saveload/Load.java
@@ -828,6 +828,20 @@ public class Load {
 					costs[j] = costsJson.getString(j);
 				}
 
+				// Skipping removed vanilla recipes
+				if (worldVer.compareTo(new Version("2.2.0-dev6")) <= 0) {
+					// Iron Ore * 4 + Coal * 1 => Iron * 1
+					if (key.equalsIgnoreCase("iron_1") &&
+						costs.length == 2 && costs[0].equalsIgnoreCase("iron Ore_4") &&
+						costs[1].equalsIgnoreCase("coal_1"))
+						continue;
+					// Gold Ore * 4 + Coal * 1 => Gold * 1
+					if (key.equalsIgnoreCase("gold_1") &&
+						costs.length == 2 && costs[0].equalsIgnoreCase("gold Ore_4") &&
+						costs[1].equalsIgnoreCase("coal_1"))
+						continue;
+				}
+
 				recipes.add(new Recipe(key, costs));
 			}
 


### PR DESCRIPTION
This changes in addition to #640, that the old recipes for 4 ores are being skipped in world loading so that they will no longer be saved in the list of unlocked recipes. This is for the forward compatibility. Players will obtain the new recipes for both iron and gold, then there should be no further problem with the shift of recipe changes.