### PR TITLE
Simplify screenshot feature

### DIFF
--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -33,6 +33,7 @@ import minicraft.screen.SignDisplayMenu;
 import minicraft.screen.TutorialDisplayHandler;
 import minicraft.screen.entry.ListEntry;
 import minicraft.screen.entry.StringEntry;
+import minicraft.util.Logging;
 import minicraft.util.Quest;
 import minicraft.util.Quest.QuestSeries;
 
@@ -168,21 +169,14 @@ public class Renderer extends Game {
 				count++;
 			}
 
-			try { // https://stackoverflow.com/a/4216635
-				int w = image.getWidth();
-				int h = image.getHeight();
-				BufferedImage before = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
-				before.getRaster().setRect(image.getData());
-				int scale = (Integer) Settings.get("screenshot");
-				// BufferedImage after = BigBufferedImage.create(scale * w, scale * h, BufferedImage.TYPE_INT_RGB);
-				AffineTransform at = new AffineTransform();
-				at.scale(scale, scale); // Setting the scaling.
-				AffineTransformOp scaleOp = new AffineTransformOp(at, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
-
-				// Use this solution without larger scales which use up a lot of memory.
-				// With scale 20, up to around 360MB overall RAM use.
-				BufferedImage after = scaleOp.filter(before, null);
-				ImageIO.write(after, "png", file);
+			try {
+				// A blank image as same as the canvas
+				BufferedImage img = new BufferedImage(canvas.getWidth(), canvas.getHeight(), BufferedImage.TYPE_INT_RGB);
+				Graphics2D g2d = img.createGraphics();
+				g2d.drawImage(image, xOffset, yOffset, ww, hh, null); // The same invoke as the one on canvas graphics
+				g2d.dispose();
+				ImageIO.write(img, "png", file);
+				Logging.PLAYER.info("Saved screenshot as {}.", file.getName());
 			} catch (IOException e) {
 				CrashHandler.errorHandle(e);
 			}

--- a/src/client/java/minicraft/core/io/Settings.java
+++ b/src/client/java/minicraft/core/io/Settings.java
@@ -15,7 +15,6 @@ public final class Settings {
 
 	static {
 		options.put("fps", new RangeEntry("minicraft.settings.fps", 10, 300, getDefaultRefreshRate())); // Has to check if the game is running in a headless mode. If it doesn't set the fps to 60
-		options.put("screenshot", new ArrayEntry<>("minicraft.settings.screenshot_scale", 1, 2, 5, 10, 15, 20)); // The magnification of screenshot. I would want to see ultimate sized.
 		options.put("diff", new ArrayEntry<>("minicraft.settings.difficulty", "minicraft.settings.difficulty.easy", "minicraft.settings.difficulty.normal", "minicraft.settings.difficulty.hard"));
 		options.get("diff").setSelection(1);
 		options.put("mode", new ArrayEntry<>("minicraft.settings.mode", "minicraft.settings.mode.survival", "minicraft.settings.mode.creative", "minicraft.settings.mode.hardcore", "minicraft.settings.mode.score"));

--- a/src/client/java/minicraft/screen/OptionsMainMenuDisplay.java
+++ b/src/client/java/minicraft/screen/OptionsMainMenuDisplay.java
@@ -15,7 +15,6 @@ public class OptionsMainMenuDisplay extends Display {
 			new SelectEntry("minicraft.display.options_display.change_key_bindings", () -> Game.setDisplay(new KeyInputDisplay())),
 			new SelectEntry("minicraft.displays.controls", () -> Game.setDisplay(new ControlsDisplay())),
 			new SelectEntry("minicraft.display.options_display.language", () -> Game.setDisplay(new LanguageSettingsDisplay())),
-			Settings.getEntry("screenshot"),
 			new SelectEntry("minicraft.display.options_display.resource_packs", () -> Game.setDisplay(new ResourcePackDisplay()))
 		)
 			.setTitle("minicraft.displays.options_main_menu")

--- a/src/client/java/minicraft/screen/OptionsWorldDisplay.java
+++ b/src/client/java/minicraft/screen/OptionsWorldDisplay.java
@@ -65,7 +65,6 @@ public class OptionsWorldDisplay extends Display {
 			new SelectEntry("minicraft.display.options_display.change_key_bindings", () -> Game.setDisplay(new KeyInputDisplay())),
 			new SelectEntry("minicraft.displays.controls", () -> Game.setDisplay(new ControlsDisplay())),
 			new SelectEntry("minicraft.display.options_display.language", () -> Game.setDisplay(new LanguageSettingsDisplay())),
-			Settings.getEntry("screenshot"),
 			new SelectEntry("minicraft.display.options_display.resource_packs", () -> Game.setDisplay(new ResourcePackDisplay()))
 		));
 	}


### PR DESCRIPTION
The option to set the screenshot scaling is removed.
Instead, the same image as the canvas is captured and saved, so that the size of the screenshots will be the same as the canvas in the window at the moment.
The option was not saved in preferences, so the save file is not affected.
This can also prevent the excess of heap size caused by temporary image objects being created and garbage-collected while heap size is not shrunk by time whatever the size of free heap.