### PR TITLE
Add copyright header

### DIFF
--- a/src/client/java/minicraft/core/Action.java
+++ b/src/client/java/minicraft/core/Action.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 @FunctionalInterface

--- a/src/client/java/minicraft/core/Condition.java
+++ b/src/client/java/minicraft/core/Condition.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 @FunctionalInterface

--- a/src/client/java/minicraft/core/CrashHandler.java
+++ b/src/client/java/minicraft/core/CrashHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import kong.unirest.Empty;

--- a/src/client/java/minicraft/core/Game.java
+++ b/src/client/java/minicraft/core/Game.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/core/Initializer.java
+++ b/src/client/java/minicraft/core/Initializer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.core.io.FileHandler;

--- a/src/client/java/minicraft/core/MonoCondition.java
+++ b/src/client/java/minicraft/core/MonoCondition.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 @FunctionalInterface

--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.core.CrashHandler.ErrorInfo;

--- a/src/client/java/minicraft/core/Updater.java
+++ b/src/client/java/minicraft/core/Updater.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.core.io.Localization;
@@ -227,7 +232,7 @@ public class Updater extends Game {
 					} else if (isMode("minicraft.settings.mode.creative") && input.getMappedKey("SHIFT-W").isClicked()) {
 						Game.setDisplay(new LevelTransitionDisplay(1));
 					}
-					
+
 					if (input.getMappedKey("F3-L").isClicked()) {
 						// Print all players on all levels, and their coordinates.
 						Logging.WORLD.info("Printing players on all levels.");

--- a/src/client/java/minicraft/core/VersionInfo.java
+++ b/src/client/java/minicraft/core/VersionInfo.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.saveload.Version;

--- a/src/client/java/minicraft/core/World.java
+++ b/src/client/java/minicraft/core/World.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/core/io/ClipboardHandler.java
+++ b/src/client/java/minicraft/core/io/ClipboardHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/core/io/FileHandler.java
+++ b/src/client/java/minicraft/core/io/FileHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/core/io/InputHandler.java
+++ b/src/client/java/minicraft/core/io/InputHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import com.badlogic.gdx.utils.SharedLibraryLoadRuntimeException;

--- a/src/client/java/minicraft/core/io/Localization.java
+++ b/src/client/java/minicraft/core/io/Localization.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import minicraft.util.Logging;

--- a/src/client/java/minicraft/core/io/Settings.java
+++ b/src/client/java/minicraft/core/io/Settings.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import minicraft.screen.entry.ArrayEntry;

--- a/src/client/java/minicraft/core/io/Sound.java
+++ b/src/client/java/minicraft/core/io/Sound.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core.io;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/entity/Arrow.java
+++ b/src/client/java/minicraft/entity/Arrow.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.entity.mob.Mob;

--- a/src/client/java/minicraft/entity/ClientTickable.java
+++ b/src/client/java/minicraft/entity/ClientTickable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 public interface ClientTickable extends Tickable {

--- a/src/client/java/minicraft/entity/Direction.java
+++ b/src/client/java/minicraft/entity/Direction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 public enum Direction {

--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.core.Action;

--- a/src/client/java/minicraft/entity/ExplosionTileTicker.java
+++ b/src/client/java/minicraft/entity/ExplosionTileTicker.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/entity/FireSpark.java
+++ b/src/client/java/minicraft/entity/FireSpark.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/ItemEntity.java
+++ b/src/client/java/minicraft/entity/ItemEntity.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.entity.mob.Player;

--- a/src/client/java/minicraft/entity/ItemHolder.java
+++ b/src/client/java/minicraft/entity/ItemHolder.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.item.Inventory;

--- a/src/client/java/minicraft/entity/Spark.java
+++ b/src/client/java/minicraft/entity/Spark.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/Tickable.java
+++ b/src/client/java/minicraft/entity/Tickable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity;
 
 public interface Tickable {

--- a/src/client/java/minicraft/entity/furniture/Bed.java
+++ b/src/client/java/minicraft/entity/furniture/Bed.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/furniture/Chest.java
+++ b/src/client/java/minicraft/entity/furniture/Chest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/entity/furniture/Composter.java
+++ b/src/client/java/minicraft/entity/furniture/Composter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.entity.Direction;

--- a/src/client/java/minicraft/entity/furniture/Crafter.java
+++ b/src/client/java/minicraft/entity/furniture/Crafter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/furniture/DeathChest.java
+++ b/src/client/java/minicraft/entity/furniture/DeathChest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/furniture/DungeonChest.java
+++ b/src/client/java/minicraft/entity/furniture/DungeonChest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.io.Localization;

--- a/src/client/java/minicraft/entity/furniture/Furniture.java
+++ b/src/client/java/minicraft/entity/furniture/Furniture.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/entity/furniture/KnightStatue.java
+++ b/src/client/java/minicraft/entity/furniture/KnightStatue.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/furniture/Lantern.java
+++ b/src/client/java/minicraft/entity/furniture/Lantern.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.gfx.SpriteLinker.LinkedSprite;

--- a/src/client/java/minicraft/entity/furniture/Spawner.java
+++ b/src/client/java/minicraft/entity/furniture/Spawner.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.furniture;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/entity/mob/AirWizard.java
+++ b/src/client/java/minicraft/entity/mob/AirWizard.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Cow.java
+++ b/src/client/java/minicraft/entity/mob/Cow.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/mob/Creeper.java
+++ b/src/client/java/minicraft/entity/mob/Creeper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/EnemyMob.java
+++ b/src/client/java/minicraft/entity/mob/EnemyMob.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Knight.java
+++ b/src/client/java/minicraft/entity/mob/Knight.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/mob/Mob.java
+++ b/src/client/java/minicraft/entity/mob/Mob.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/MobAi.java
+++ b/src/client/java/minicraft/entity/mob/MobAi.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/PassiveMob.java
+++ b/src/client/java/minicraft/entity/mob/PassiveMob.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Pig.java
+++ b/src/client/java/minicraft/entity/mob/Pig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/mob/Player.java
+++ b/src/client/java/minicraft/entity/mob/Player.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Sheep.java
+++ b/src/client/java/minicraft/entity/mob/Sheep.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/mob/Skeleton.java
+++ b/src/client/java/minicraft/entity/mob/Skeleton.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Slime.java
+++ b/src/client/java/minicraft/entity/mob/Slime.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/entity/mob/Snake.java
+++ b/src/client/java/minicraft/entity/mob/Snake.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/mob/Zombie.java
+++ b/src/client/java/minicraft/entity/mob/Zombie.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.mob;
 
 import minicraft.core.io.Settings;

--- a/src/client/java/minicraft/entity/particle/BurnParticle.java
+++ b/src/client/java/minicraft/entity/particle/BurnParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.SpriteLinker;

--- a/src/client/java/minicraft/entity/particle/FireParticle.java
+++ b/src/client/java/minicraft/entity/particle/FireParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.SpriteLinker.LinkedSprite;

--- a/src/client/java/minicraft/entity/particle/Particle.java
+++ b/src/client/java/minicraft/entity/particle/Particle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.entity.ClientTickable;

--- a/src/client/java/minicraft/entity/particle/SandParticle.java
+++ b/src/client/java/minicraft/entity/particle/SandParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.SpriteLinker.LinkedSprite;

--- a/src/client/java/minicraft/entity/particle/SmashParticle.java
+++ b/src/client/java/minicraft/entity/particle/SmashParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.SpriteLinker.LinkedSprite;

--- a/src/client/java/minicraft/entity/particle/TextParticle.java
+++ b/src/client/java/minicraft/entity/particle/TextParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.Color;

--- a/src/client/java/minicraft/entity/particle/WaterParticle.java
+++ b/src/client/java/minicraft/entity/particle/WaterParticle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.entity.particle;
 
 import minicraft.gfx.SpriteLinker;

--- a/src/client/java/minicraft/gfx/Color.java
+++ b/src/client/java/minicraft/gfx/Color.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 public class Color {

--- a/src/client/java/minicraft/gfx/Dimension.java
+++ b/src/client/java/minicraft/gfx/Dimension.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 public class Dimension {

--- a/src/client/java/minicraft/gfx/Ellipsis.java
+++ b/src/client/java/minicraft/gfx/Ellipsis.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.core.Updater;

--- a/src/client/java/minicraft/gfx/Font.java
+++ b/src/client/java/minicraft/gfx/Font.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.core.Renderer;

--- a/src/client/java/minicraft/gfx/FontStyle.java
+++ b/src/client/java/minicraft/gfx/FontStyle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.screen.RelPos;

--- a/src/client/java/minicraft/gfx/Insets.java
+++ b/src/client/java/minicraft/gfx/Insets.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 public class Insets {

--- a/src/client/java/minicraft/gfx/MinicraftImage.java
+++ b/src/client/java/minicraft/gfx/MinicraftImage.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.gfx.SpriteLinker.LinkedSprite;

--- a/src/client/java/minicraft/gfx/Point.java
+++ b/src/client/java/minicraft/gfx/Point.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 public class Point {

--- a/src/client/java/minicraft/gfx/Rectangle.java
+++ b/src/client/java/minicraft/gfx/Rectangle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.screen.RelPos;

--- a/src/client/java/minicraft/gfx/Screen.java
+++ b/src/client/java/minicraft/gfx/Screen.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.core.Renderer;

--- a/src/client/java/minicraft/gfx/Sprite.java
+++ b/src/client/java/minicraft/gfx/Sprite.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 /**

--- a/src/client/java/minicraft/gfx/SpriteAnimation.java
+++ b/src/client/java/minicraft/gfx/SpriteAnimation.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.core.Renderer;

--- a/src/client/java/minicraft/gfx/SpriteLinker.java
+++ b/src/client/java/minicraft/gfx/SpriteLinker.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.gfx;
 
 import minicraft.core.Renderer;

--- a/src/client/java/minicraft/item/ArmorItem.java
+++ b/src/client/java/minicraft/item/ArmorItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.entity.Direction;

--- a/src/client/java/minicraft/item/BookItem.java
+++ b/src/client/java/minicraft/item/BookItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/BucketItem.java
+++ b/src/client/java/minicraft/item/BucketItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/ClothingItem.java
+++ b/src/client/java/minicraft/item/ClothingItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/FishingData.java
+++ b/src/client/java/minicraft/item/FishingData.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.saveload.Load;

--- a/src/client/java/minicraft/item/FishingRodItem.java
+++ b/src/client/java/minicraft/item/FishingRodItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/FoodItem.java
+++ b/src/client/java/minicraft/item/FoodItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.entity.Direction;

--- a/src/client/java/minicraft/item/FurnitureItem.java
+++ b/src/client/java/minicraft/item/FurnitureItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/HeartItem.java
+++ b/src/client/java/minicraft/item/HeartItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Updater;

--- a/src/client/java/minicraft/item/Inventory.java
+++ b/src/client/java/minicraft/item/Inventory.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.util.Logging;

--- a/src/client/java/minicraft/item/Item.java
+++ b/src/client/java/minicraft/item/Item.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.io.Localization;

--- a/src/client/java/minicraft/item/Items.java
+++ b/src/client/java/minicraft/item/Items.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.util.Logging;

--- a/src/client/java/minicraft/item/PotionItem.java
+++ b/src/client/java/minicraft/item/PotionItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/PotionType.java
+++ b/src/client/java/minicraft/item/PotionType.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/PowerGloveItem.java
+++ b/src/client/java/minicraft/item/PowerGloveItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/client/java/minicraft/item/Recipe.java
+++ b/src/client/java/minicraft/item/Recipe.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/Recipes.java
+++ b/src/client/java/minicraft/item/Recipes.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.entity.furniture.Bed;

--- a/src/client/java/minicraft/item/StackableItem.java
+++ b/src/client/java/minicraft/item/StackableItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/SummonItem.java
+++ b/src/client/java/minicraft/item/SummonItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/TileItem.java
+++ b/src/client/java/minicraft/item/TileItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/ToolItem.java
+++ b/src/client/java/minicraft/item/ToolItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/item/ToolType.java
+++ b/src/client/java/minicraft/item/ToolType.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 public enum ToolType {

--- a/src/client/java/minicraft/item/UnknownItem.java
+++ b/src/client/java/minicraft/item/UnknownItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.gfx.SpriteLinker;

--- a/src/client/java/minicraft/item/WateringCanItem.java
+++ b/src/client/java/minicraft/item/WateringCanItem.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.item;
 
 import minicraft.entity.Direction;

--- a/src/client/java/minicraft/level/Level.java
+++ b/src/client/java/minicraft/level/Level.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/LevelGen.java
+++ b/src/client/java/minicraft/level/LevelGen.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/Structure.java
+++ b/src/client/java/minicraft/level/Structure.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level;
 
 import minicraft.entity.furniture.Crafter;

--- a/src/client/java/minicraft/level/tile/BossDoorTile.java
+++ b/src/client/java/minicraft/level/tile/BossDoorTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/BossFloorTile.java
+++ b/src/client/java/minicraft/level/tile/BossFloorTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/BossWallTile.java
+++ b/src/client/java/minicraft/level/tile/BossWallTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/CactusTile.java
+++ b/src/client/java/minicraft/level/tile/CactusTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/CloudTile.java
+++ b/src/client/java/minicraft/level/tile/CloudTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/ConnectTile.java
+++ b/src/client/java/minicraft/level/tile/ConnectTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 

--- a/src/client/java/minicraft/level/tile/DecorTile.java
+++ b/src/client/java/minicraft/level/tile/DecorTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/DirtTile.java
+++ b/src/client/java/minicraft/level/tile/DirtTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/DoorTile.java
+++ b/src/client/java/minicraft/level/tile/DoorTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/ExplodedTile.java
+++ b/src/client/java/minicraft/level/tile/ExplodedTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.entity.Entity;

--- a/src/client/java/minicraft/level/tile/FenceTile.java
+++ b/src/client/java/minicraft/level/tile/FenceTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/FloorTile.java
+++ b/src/client/java/minicraft/level/tile/FloorTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/FlowerTile.java
+++ b/src/client/java/minicraft/level/tile/FlowerTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/GrassTile.java
+++ b/src/client/java/minicraft/level/tile/GrassTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/HardRockTile.java
+++ b/src/client/java/minicraft/level/tile/HardRockTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/HoleTile.java
+++ b/src/client/java/minicraft/level/tile/HoleTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.entity.Entity;

--- a/src/client/java/minicraft/level/tile/InfiniteFallTile.java
+++ b/src/client/java/minicraft/level/tile/InfiniteFallTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/LavaBrickTile.java
+++ b/src/client/java/minicraft/level/tile/LavaBrickTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/LavaTile.java
+++ b/src/client/java/minicraft/level/tile/LavaTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.entity.Entity;

--- a/src/client/java/minicraft/level/tile/MaterialTile.java
+++ b/src/client/java/minicraft/level/tile/MaterialTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/OreTile.java
+++ b/src/client/java/minicraft/level/tile/OreTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/PathTile.java
+++ b/src/client/java/minicraft/level/tile/PathTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/RockTile.java
+++ b/src/client/java/minicraft/level/tile/RockTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/SandTile.java
+++ b/src/client/java/minicraft/level/tile/SandTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/SaplingTile.java
+++ b/src/client/java/minicraft/level/tile/SaplingTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/SignTile.java
+++ b/src/client/java/minicraft/level/tile/SignTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/StairsTile.java
+++ b/src/client/java/minicraft/level/tile/StairsTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/Tile.java
+++ b/src/client/java/minicraft/level/tile/Tile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.World;

--- a/src/client/java/minicraft/level/tile/Tiles.java
+++ b/src/client/java/minicraft/level/tile/Tiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/level/tile/TorchTile.java
+++ b/src/client/java/minicraft/level/tile/TorchTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/TreeTile.java
+++ b/src/client/java/minicraft/level/tile/TreeTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/WallTile.java
+++ b/src/client/java/minicraft/level/tile/WallTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/WaterTile.java
+++ b/src/client/java/minicraft/level/tile/WaterTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.entity.Entity;

--- a/src/client/java/minicraft/level/tile/WoolTile.java
+++ b/src/client/java/minicraft/level/tile/WoolTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/entity/SignTileEntity.java
+++ b/src/client/java/minicraft/level/tile/entity/SignTileEntity.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.entity;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/level/tile/farming/CarrotTile.java
+++ b/src/client/java/minicraft/level/tile/farming/CarrotTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/level/tile/farming/CropTile.java
+++ b/src/client/java/minicraft/level/tile/farming/CropTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/farming/FarmTile.java
+++ b/src/client/java/minicraft/level/tile/farming/FarmTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.core.io.Sound;

--- a/src/client/java/minicraft/level/tile/farming/HeavenlyBerriesTile.java
+++ b/src/client/java/minicraft/level/tile/farming/HeavenlyBerriesTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/level/tile/farming/HellishBerriesTile.java
+++ b/src/client/java/minicraft/level/tile/farming/HellishBerriesTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/level/tile/farming/PotatoTile.java
+++ b/src/client/java/minicraft/level/tile/farming/PotatoTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/level/tile/farming/TomatoTile.java
+++ b/src/client/java/minicraft/level/tile/farming/TomatoTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/level/tile/farming/WheatTile.java
+++ b/src/client/java/minicraft/level/tile/farming/WheatTile.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.level.tile.farming;
 
 import minicraft.gfx.Screen;

--- a/src/client/java/minicraft/network/Analytics.java
+++ b/src/client/java/minicraft/network/Analytics.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.network;
 
 import kong.unirest.Callback;

--- a/src/client/java/minicraft/network/MinicraftProtocol.java
+++ b/src/client/java/minicraft/network/MinicraftProtocol.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.network;
 
 import java.util.Arrays;

--- a/src/client/java/minicraft/network/Network.java
+++ b/src/client/java/minicraft/network/Network.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.network;
 
 import kong.unirest.HttpResponse;

--- a/src/client/java/minicraft/saveload/LegacyLoad.java
+++ b/src/client/java/minicraft/saveload/LegacyLoad.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.saveload;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/saveload/Load.java
+++ b/src/client/java/minicraft/saveload/Load.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.saveload;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/saveload/Save.java
+++ b/src/client/java/minicraft/saveload/Save.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.saveload;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/saveload/Version.java
+++ b/src/client/java/minicraft/saveload/Version.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.saveload;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/client/java/minicraft/screen/AchievementsDisplay.java
+++ b/src/client/java/minicraft/screen/AchievementsDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/BookDisplay.java
+++ b/src/client/java/minicraft/screen/BookDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/ContainerDisplay.java
+++ b/src/client/java/minicraft/screen/ContainerDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/ControlsDisplay.java
+++ b/src/client/java/minicraft/screen/ControlsDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/CraftingDisplay.java
+++ b/src/client/java/minicraft/screen/CraftingDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/Display.java
+++ b/src/client/java/minicraft/screen/Display.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/EndGameDisplay.java
+++ b/src/client/java/minicraft/screen/EndGameDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/InfoDisplay.java
+++ b/src/client/java/minicraft/screen/InfoDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/InventoryMenu.java
+++ b/src/client/java/minicraft/screen/InventoryMenu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/ItemListMenu.java
+++ b/src/client/java/minicraft/screen/ItemListMenu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.gfx.Point;

--- a/src/client/java/minicraft/screen/KeyInputDisplay.java
+++ b/src/client/java/minicraft/screen/KeyInputDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/LanguageSettingsDisplay.java
+++ b/src/client/java/minicraft/screen/LanguageSettingsDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/LevelTransitionDisplay.java
+++ b/src/client/java/minicraft/screen/LevelTransitionDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/LoadingDisplay.java
+++ b/src/client/java/minicraft/screen/LoadingDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/Menu.java
+++ b/src/client/java/minicraft/screen/Menu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/MultiplayerDisplay.java
+++ b/src/client/java/minicraft/screen/MultiplayerDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import kong.unirest.Callback;

--- a/src/client/java/minicraft/screen/OnScreenKeyboardMenu.java
+++ b/src/client/java/minicraft/screen/OnScreenKeyboardMenu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/OptionsMainMenuDisplay.java
+++ b/src/client/java/minicraft/screen/OptionsMainMenuDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/OptionsWorldDisplay.java
+++ b/src/client/java/minicraft/screen/OptionsWorldDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/PauseDisplay.java
+++ b/src/client/java/minicraft/screen/PauseDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/PlayDisplay.java
+++ b/src/client/java/minicraft/screen/PlayDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/PlayerDeathDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerDeathDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerInvDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/PopupDisplay.java
+++ b/src/client/java/minicraft/screen/PopupDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/QuestsDisplay.java
+++ b/src/client/java/minicraft/screen/QuestsDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/screen/RecipeMenu.java
+++ b/src/client/java/minicraft/screen/RecipeMenu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.entity.mob.Player;

--- a/src/client/java/minicraft/screen/RelPos.java
+++ b/src/client/java/minicraft/screen/RelPos.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.gfx.Dimension;

--- a/src/client/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/client/java/minicraft/screen/ResourcePackDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/screen/SignDisplay.java
+++ b/src/client/java/minicraft/screen/SignDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/SignDisplayMenu.java
+++ b/src/client/java/minicraft/screen/SignDisplayMenu.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/SkinDisplay.java
+++ b/src/client/java/minicraft/screen/SkinDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.CrashHandler;

--- a/src/client/java/minicraft/screen/TempDisplay.java
+++ b/src/client/java/minicraft/screen/TempDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/TitleDisplay.java
+++ b/src/client/java/minicraft/screen/TitleDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/TutorialDisplayHandler.java
+++ b/src/client/java/minicraft/screen/TutorialDisplayHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/WorldGenDisplay.java
+++ b/src/client/java/minicraft/screen/WorldGenDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/WorldSelectDisplay.java
+++ b/src/client/java/minicraft/screen/WorldSelectDisplay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen;
 
 import com.studiohartman.jamepad.ControllerButton;

--- a/src/client/java/minicraft/screen/entry/ArrayEntry.java
+++ b/src/client/java/minicraft/screen/entry/ArrayEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/BlankEntry.java
+++ b/src/client/java/minicraft/screen/entry/BlankEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/BooleanEntry.java
+++ b/src/client/java/minicraft/screen/entry/BooleanEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.Localization;

--- a/src/client/java/minicraft/screen/entry/ChangeListener.java
+++ b/src/client/java/minicraft/screen/entry/ChangeListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 @FunctionalInterface

--- a/src/client/java/minicraft/screen/entry/InputEntry.java
+++ b/src/client/java/minicraft/screen/entry/InputEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.ClipboardHandler;

--- a/src/client/java/minicraft/screen/entry/ItemEntry.java
+++ b/src/client/java/minicraft/screen/entry/ItemEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/ItemListing.java
+++ b/src/client/java/minicraft/screen/entry/ItemListing.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.item.Item;

--- a/src/client/java/minicraft/screen/entry/KeyInputEntry.java
+++ b/src/client/java/minicraft/screen/entry/KeyInputEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/LinkEntry.java
+++ b/src/client/java/minicraft/screen/entry/LinkEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.Game;

--- a/src/client/java/minicraft/screen/entry/ListEntry.java
+++ b/src/client/java/minicraft/screen/entry/ListEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/RangeEntry.java
+++ b/src/client/java/minicraft/screen/entry/RangeEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 public class RangeEntry extends ArrayEntry<Integer> {

--- a/src/client/java/minicraft/screen/entry/RecipeEntry.java
+++ b/src/client/java/minicraft/screen/entry/RecipeEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/screen/entry/SelectEntry.java
+++ b/src/client/java/minicraft/screen/entry/SelectEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.Action;

--- a/src/client/java/minicraft/screen/entry/StringEntry.java
+++ b/src/client/java/minicraft/screen/entry/StringEntry.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;

--- a/src/client/java/minicraft/util/Achievement.java
+++ b/src/client/java/minicraft/util/Achievement.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 public class Achievement {

--- a/src/client/java/minicraft/util/AdvancementElement.java
+++ b/src/client/java/minicraft/util/AdvancementElement.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.core.World;

--- a/src/client/java/minicraft/util/BookData.java
+++ b/src/client/java/minicraft/util/BookData.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.item.BookItem;

--- a/src/client/java/minicraft/util/Logging.java
+++ b/src/client/java/minicraft/util/Logging.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import org.tinylog.Logger;

--- a/src/client/java/minicraft/util/MyUtils.java
+++ b/src/client/java/minicraft/util/MyUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 public final class MyUtils {

--- a/src/client/java/minicraft/util/Quest.java
+++ b/src/client/java/minicraft/util/Quest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.screen.QuestsDisplay;

--- a/src/client/java/minicraft/util/TinylogLoggingConfiguration.java
+++ b/src/client/java/minicraft/util/TinylogLoggingConfiguration.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.util.TinylogLoggingConfiguration.WriterConfig.TagList;

--- a/src/client/java/minicraft/util/TinylogLoggingProvider.java
+++ b/src/client/java/minicraft/util/TinylogLoggingProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.util.TinylogLoggingConfiguration.WriterConfig;

--- a/src/client/java/minicraft/util/TutorialElement.java
+++ b/src/client/java/minicraft/util/TutorialElement.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 import minicraft.screen.TutorialDisplayHandler;

--- a/src/client/java/minicraft/util/Vector2.java
+++ b/src/client/java/minicraft/util/Vector2.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.util;
 
 public class Vector2 {

--- a/src/client/resources/tinylog.properties
+++ b/src/client/resources/tinylog.properties
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2024 Minicraft+ Developers and Contributors
+# SPDX-License-Identifier: GPL-3.0-only
+#
+
 # suppress inspection "UnusedProperty" for whole file
 # If there is any modification in this file,
 # minicraft.util.TinylogLoggingProvider and/or minicraft.util.TinylogLoggingConfiguration might also need to be modified.

--- a/src/common/java/minicraft/saveload/Perseverance.java
+++ b/src/common/java/minicraft/saveload/Perseverance.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.saveload;
 
 public class Perseverance {

--- a/src/server/java/minicraft/core/Server.java
+++ b/src/server/java/minicraft/core/Server.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Minicraft+ Developers and Contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package minicraft.core;
 
 public class Server {


### PR DESCRIPTION
After investigation of GPL license, it requires a copyright notice included in each project file [GNU.org](https://www.gnu.org/licenses/gpl-howto.html) [StackOverflow answer](https://softwareengineering.stackexchange.com/a/357796).
The follow header is added to each Java source files:
```java
/*
 * Copyright (c) 2024 Minicraft+ Developers and Contributors
 * SPDX-License-Identifier: GPL-3.0-only
 */
```