### PR TITLE
Remove redundant hardcoded code to tile corner rendering

### DIFF
--- a/src/client/java/minicraft/level/tile/GrassTile.java
+++ b/src/client/java/minicraft/level/tile/GrassTile.java
@@ -15,7 +15,7 @@ import minicraft.util.AdvancementElement;
 
 public class GrassTile extends Tile {
 	private static final SpriteAnimation sprite = new SpriteAnimation(SpriteType.Tile, "grass")
-		.setConnectionChecker((level, x, y, tile, side) -> !side || tile.connectsToGrass(level, x, y))
+		.setConnectionChecker((level, x, y, tile, side) -> tile.connectsToGrass(level, x, y))
 		.setSingletonWithConnective(true);
 
 	protected GrassTile(String name) {

--- a/src/client/java/minicraft/level/tile/SandTile.java
+++ b/src/client/java/minicraft/level/tile/SandTile.java
@@ -18,7 +18,7 @@ import minicraft.util.AdvancementElement;
 
 public class SandTile extends Tile {
 	private static SpriteAnimation sprite = new SpriteAnimation(SpriteType.Tile, "sand")
-		.setConnectionChecker((level, x, y, tile, side) -> !side || tile.connectsToSand(level, x, y))
+		.setConnectionChecker((level, x, y, tile, side) -> tile.connectsToSand(level, x, y))
 		.setSingletonWithConnective(true);
 
 	protected SandTile(String name) {


### PR DESCRIPTION
Resolves #700.
This restriction exists for both `GrassTile` and `SandTile`.
Related investigation to the effect is done previously:
> The effects when there are tiles exist on orthogonal directions (for each pair of orthogonal directions):
> ```mermaid
> flowchart LR
>     A1[corner] --> B11[diagonal]
>     A1 --> B12[!diagonal]
>     A2[!corner] --> B21[diagonal]
>     A2 --> B22[!diagonal]
>     B11 --> single
>     B21 --> single
>     B12 --> corner
>     B22 --> full
>     B12 -.-> B11
>     B22 -.-> B21
> ```
> > single: singleton texture with connective; takes place only on corner parts; using "full" over "border center"
> > corner: whether corner texture is set
> > diagonal: whether diagonal tile exists
> > *dotted arrow*: effect of `!side` code

Source: https://github.com/MinicraftPlus/minicraft-plus-revived/issues/700#issuecomment-2377431591

This part of code has existed already before the last big update to the resource pack system. It was probably aiming to resolve the issue that a missing of corner might cause rendering misfunctioning. In the past, it actually functioned as like having `checkCorners == false`, by referring to 34c4381915b9781cc33169754313ee45ec02c7fe. What I can see is that, that method overwrite is kind of pointless as the constructions of both `SandTile` and `GrassTile` already made `checkCorners = false`. However, after deeper investigation, the method overwrite had been implemented before `checkCorners` (as you can see in 8881490686ad9705b637af87ba6de0afa05f2a46). It is possibly because the developers had not realized the overshadowed functionality of code when adding `checkCorners`. Anyway, this redundant part of code which is as well limiting the customizability of resources is eventually removed here.