### PR TITLE
Fix issues regarding entity movement methods

### DIFF
--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -176,12 +176,10 @@ public abstract class Entity implements Tickable {
 	 * Moves the entity a long only on X axis without "teleporting".
 	 * Will throw exception otherwise.<br>
 	 * Note that this should only be invoked by {@link #move(int, int)}.
-	 * @param d Displacement relative to the axis.
+	 * @param d Displacement relative to the axis; should be non-zero
 	 * @return true if the move was successful, false if not.
 	 */
 	protected boolean moveX(int d) {
-		if (d == 0) return true; // Was not stopped
-
 		//boolean interact = true;//!Game.isValidClient() || this instanceof ClientTickable;
 
 		// Taking the axis of movement (towards) as the front axis, and the horizontal axis with another axis.
@@ -210,12 +208,10 @@ public abstract class Entity implements Tickable {
 	 * Moves the entity a long only on X axis without "teleporting".
 	 * Will throw exception otherwise.<br>
 	 * Note that this should only be invoked by {@link #move(int, int)}.
-	 * @param d Displacement relative to the axis.
-	 * @return true if the move was successful, false if not.
+	 * @param d Displacement relative to the axis; should be non-zero
+	 * @return true if there is movement, false if not.
 	 */
 	protected boolean moveY(int d) {
-		if (d == 0) return true; // Was not stopped
-
 		//boolean interact = true;//!Game.isValidClient() || this instanceof ClientTickable;
 
 		// Taking the axis of movement (towards) as the front axis, and the horizontal axis with another axis.

--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -156,12 +156,14 @@ public abstract class Entity implements Tickable {
 	 * Moves an entity horizontally and vertically. Returns whether entity was unimpeded in it's movement.
 	 */
 	public boolean move(int xd, int yd) {
+		// TODO Validate existence of `Updater.saving` here, may potentially cause issue
 		if (Updater.saving || (xd == 0 && yd == 0)) return true; // Pretend that it kept moving
 
 		boolean stopped = true; // Used to check if the entity has BEEN stopped, COMPLETELY; below checks for a lack of collision.
+		// Either xd or yd must be non-zero, so at least either one of them is invoked.
 		//noinspection RedundantIfStatement
-		if (moveX(xd)) stopped = false; // Becomes false if horizontal movement was successful.
-		if (moveY(yd)) stopped = false; // Becomes false if vertical movement was successful.
+		if (xd != 0 && moveX(xd)) stopped = false; // Becomes false if horizontal movement was successful.
+		if (yd != 0 && moveY(yd)) stopped = false; // Becomes false if vertical movement was successful.
 		if (!stopped) {
 			int xt = x >> 4; // The x tile coordinate that the entity is standing on.
 			int yt = y >> 4; // The y tile coordinate that the entity is standing on.
@@ -172,7 +174,8 @@ public abstract class Entity implements Tickable {
 
 	/**
 	 * Moves the entity a long only on X axis without "teleporting".
-	 * Will throw exception otherwise.
+	 * Will throw exception otherwise.<br>
+	 * Note that this should only be invoked by {@link #move(int, int)}.
 	 * @param d Displacement relative to the axis.
 	 * @return true if the move was successful, false if not.
 	 */
@@ -205,7 +208,8 @@ public abstract class Entity implements Tickable {
 
 	/**
 	 * Moves the entity a long only on X axis without "teleporting".
-	 * Will throw exception otherwise.
+	 * Will throw exception otherwise.<br>
+	 * Note that this should only be invoked by {@link #move(int, int)}.
 	 * @param d Displacement relative to the axis.
 	 * @return true if the move was successful, false if not.
 	 */

--- a/src/client/java/minicraft/entity/FireSpark.java
+++ b/src/client/java/minicraft/entity/FireSpark.java
@@ -11,7 +11,7 @@ public class FireSpark extends Entity {
 	private static final SpriteLinker.LinkedSprite sprite = new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Entity, "spark");
 
 	private final int lifeTime; // How much time until the spark disappears
-	private final double xa, ya; // The x and y acceleration
+	private final double xa, ya; // The x and y velocities
 	private double xx, yy; // The x and y positions
 	private int time; // The amount of time that has passed
 	private int stoppedTime;
@@ -52,19 +52,7 @@ public class FireSpark extends Entity {
 				return;
 			}
 		} else {
-			// Move the spark:
-			int x0 = (int) xx; // Original position
-			int y0 = (int) yy;
-			xx += xa; // Final position
-			yy += ya;
-			boolean stopped = true;
-			//noinspection RedundantIfStatement
-			if (moveX(((int) xx) - x0))
-				stopped = false; // This kind of difference is handled due to errors by flooring.
-			if (moveY(((int) yy) - y0)) stopped = false;
-			if (stopped) {
-				this.stopped = true;
-			}
+			move();
 		}
 
 		Player player = getClosestPlayer();
@@ -73,6 +61,24 @@ public class FireSpark extends Entity {
 				player.burn(5); // Burn the player for 5 seconds
 			}
 		}
+	}
+
+	public boolean move() {
+		// Moving the spark:
+		// Real coordinate (int) fields: x, y
+		// Virtual coordinate (double) fields: xx, yy
+		// Entity real movement on the world is based on real coordinates,
+		// but this entity moves in a smaller scale, thus double virtual coordinates are used.
+		// However, practically it may have not moved a full unit/"pixel",
+		// so this is not quite perfect, but should be enough and negligible
+		// at the moment, to simply the situation.
+		xx += xa; // Final position
+		yy += ya;
+		// This kind of difference is handled due to errors by flooring.
+		// New real coordinates are calculated and saved by #move
+		boolean moved = move((int) xx - x, (int) yy - y);
+		if (!moved) this.stopped = true; // Suppose and assume it is fully stopped
+		return moved;
 	}
 
 	/**


### PR DESCRIPTION
Main issue fixed:

`Entity#move` still returned `true` even when not moved as either x or y delta is zero. The boolean result should indicate whether the entity *is moved* (`false` whenever completely not moved), when any non-zero argument is passed. (This issue was found when doing #592)
Furthermore, the line
```java
if (d == 0) return true; // Was not stopped
```
was kept just because the original method contains the check, but was for when *both x and y delta are zero*. The code is then checked somehow to be logically incorrect, and the actual logically correct line already exists in `#move` as
```java
if (Updater.saving || (xd == 0 && yd == 0)) return true; // Pretend that it kept moving
```

Minor (potential) issues in `FireSpark` (mostly fixed):
- `Entity#x` and `Entity#y` used in `#moveX` and `#moveY` were not taken into account when calculating distance of movement, which may lead to potential increasing gap between "real coordinates" and "virutal coordinates".
- Superclass `#move` is not called, which may lead to inconsistent operations between overriding code and original method.
- Suppose this made just negligible effect to the current system, this issue is not fixed to simplify the situation. As real movement handled by `#move` depends on *integral* real coordinates, it would still return as "not moved" when the movement (from virtual *double* coordinates) made less than a unit/"pixel" of movement (no "movement" in integral *floored* coordinates), leading to unexpected result. However, at the moment, no obvious impact is found.