### PR TITLE
Fix unconstrained code for PlayerInvDisplay menu updating

### DIFF
--- a/src/client/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerInvDisplay.java
@@ -358,9 +358,11 @@ public class PlayerInvDisplay extends Display {
 
 	private void update() {
 		menus[0] = new InventoryMenu((InventoryMenu) menus[0]);
-		menus[1] = new InventoryMenu((InventoryMenu) menus[1]);
-		menus[1].translate(menus[0].getBounds().getWidth() + padding, 0);
-		onSelectionChange(0, selection);
+		if (creativeMode) {
+			menus[1] = new InventoryMenu((InventoryMenu) menus[1]);
+			menus[1].translate(menus[0].getBounds().getWidth() + padding, 0);
+			onSelectionChange(0, selection);
+		}
 		itemDescription = getDescription();
 	}
 }


### PR DESCRIPTION
Fixes #703
This greatly demonstrated an example of what could happen when low level programming bugged in high level language. If it is C/C++, just undefined bahaviour instead of an exception or error.

This should be a bug since 2.2.0-dev1 (29f6ff86ffaeaf98c669b269800b133997c445a3). I believe it was because the code was copied directly from `ContainerDisplay` without further examination and modification. It should be a `ArrayIndexOutOfBoundsException` but since 2.2.0-dev4 (33c50838153e0e758845f64148e01da055faa70b), a description menu has been added, so the 1st menu become the description menu when not in creative mode and thus not the requested `InventoryMenu` (`ClassCastException`), causing the exception.

The part of code is executed when a stack of item is updated when in menu or inventory is updated when items moved between player inventory and list of item (only in creative mode). Only the action of dropping item updating item stacks is available for non-creative mode, other than the deletion of items in creative mode. The logic is errored and an exception is thrown only when in non-creative mode. Since `2.2.0-dev1`, `ArrayIndexOutOfBoundsException` will be thrown while since `2.2.0-dev4`, `ClassCastException` will be thrown, on the same line of code.