### PR TITLE
Fixed Hardcore Death Menu Exploit

### DIFF
--- a/src/client/java/minicraft/screen/PlayerDeathDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerDeathDisplay.java
@@ -38,7 +38,10 @@ public class PlayerDeathDisplay extends Display {
 			new Save(WorldSelectDisplay.getWorldName());
 			Game.setDisplay(new TitleDisplay());
 		}));
-		entries.add(new SelectEntry("minicraft.displays.player_death.quit", () -> Game.setDisplay(new TitleDisplay())));
+
+		if (!Game.isMode("minicraft.settings.mode.hardcore")) {
+			entries.add(new SelectEntry("minicraft.displays.player_death.quit", () -> Game.setDisplay(new TitleDisplay())));
+		}
 
 		menus = new Menu[] {
 			new Menu.Builder(true, 0, RelPos.LEFT, entries)


### PR DESCRIPTION
This fix addresses an exploit in Hardcore mode where, upon death, a player could continue playing in the same world. If the player manually saved the world before dying, they could simply choose the "Quit" option from the death menu to return to the main menu without saving, and then reload the world