### PR TITLE
Fix paths returned by ResourcePack::getFiles

### DIFF
--- a/src/client/java/minicraft/screen/ResourcePackDisplay.java
+++ b/src/client/java/minicraft/screen/ResourcePackDisplay.java
@@ -522,7 +522,11 @@ public class ResourcePackDisplay extends Display {
 					stream.forEach(p -> {
 						boolean isDir = Files.isDirectory(p);
 						if ((filter == null || filter.check(p, isDir))) {
-							paths.add(this.packRootPath.relativize(p).toString().replaceAll("\\\\", "/") + (isDir ? "/" : ""));
+							String pathStr = this.packRootPath.relativize(p).toString().replaceAll("\\\\", "/");
+							if (isDir && !pathStr.endsWith("/")) {
+								pathStr += "/";
+							}
+							paths.add(pathStr);
 						}
 					});
 				} catch (IOException e) {


### PR DESCRIPTION
In java 8 the client/game jar resource pack returns the directory paths with '/'.

It should only append '/' at the end when it's a directory path and the path doesn't end with '/'.