### PR TITLE
Use ItemStack with components for the instance properties

### DIFF
--- a/src/client/java/minicraft/core/Renderer.java
+++ b/src/client/java/minicraft/core/Renderer.java
@@ -19,11 +19,13 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.PotionType;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
 import minicraft.item.WateringCanItem;
+import minicraft.item.component.ComponentTypes;
 import minicraft.level.Level;
 import minicraft.screen.LoadingDisplay;
 import minicraft.screen.Menu;
@@ -41,11 +43,8 @@ import javax.imageio.ImageIO;
 
 import java.awt.Canvas;
 import java.awt.Graphics2D;
-import java.awt.geom.AffineTransform;
-import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferInt;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -237,9 +236,9 @@ public class Renderer extends Game {
 
 
 		// This checks if the player is holding a bow, and shows the arrow counter accordingly.
-		if (player.activeItem instanceof ToolItem) {
-			if (((ToolItem) player.activeItem).type == ToolType.Bow) {
-				int ac = player.getInventory().count(Items.arrowItem);
+		if (player.activeItem != null && player.activeItem.getItem() instanceof ToolItem) {
+			if (((ToolItem) player.activeItem.getItem()).type == ToolType.Bow) {
+				int ac = player.getInventory().count(new ItemStack(Items.arrowItem));
 				// "^" is an infinite symbol.
 				if (isMode("minicraft.settings.mode.creative") || ac >= 10000)
 					Font.drawBackground("	x" + "^", screen, 84, Screen.h - 16);
@@ -318,19 +317,19 @@ public class Renderer extends Game {
 		}
 
 		// TOOL DURABILITY STATUS
-		if (player.activeItem instanceof ToolItem) {
+		if (player.activeItem != null && player.activeItem.getItem() instanceof ToolItem) {
 			// Draws the text
-			ToolItem tool = (ToolItem) player.activeItem;
-			int dura = tool.dur * 100 / (tool.type.durability * (tool.level + 1));
+			ToolItem tool = (ToolItem) player.activeItem.getItem();
+			int dura = player.activeItem.get(ComponentTypes.DURABILITY) * 100 / (tool.type.durability * (tool.level + 1));
 			int green = (int) (dura * 2.55f); // Let duration show as normal.
 			Font.drawBackground(dura + "%", screen, 164, Screen.h - 16, Color.get(1, 255 - green, green, 0));
 		}
 
 		// WATERING CAN CONTAINER STATUS
-		if (player.activeItem instanceof WateringCanItem) {
+		if (player.activeItem != null && player.activeItem.getItem() instanceof WateringCanItem) {
 			// Draws the text
-			WateringCanItem tin = (WateringCanItem) player.activeItem;
-			int dura = tin.content * 100 / tin.CAPACITY;
+			WateringCanItem tin = (WateringCanItem) player.activeItem.getItem();
+			int dura = player.activeItem.get(ComponentTypes.WATERING_CAN).content() * 100 / tin.CAPACITY;
 			int green = (int) (dura * 2.55f); // Let duration show as normal.
 			Font.drawBackground(dura + "%", screen, 164, Screen.h - 16, Color.get(1, 255 - green, green, 0));
 		}
@@ -381,7 +380,7 @@ public class Renderer extends Game {
 				// Renders armor
 				int armor = player.armor * Player.maxStat / Player.maxArmor;
 				if (i <= armor && player.curArmor != null) {
-					screen.render(i * 8, Screen.h - 24, player.curArmor.sprite);
+					screen.render(i * 8, Screen.h - 24, player.curArmor.getSprite());
 				}
 
 				if (player.staminaRechargeDelay > 0) {

--- a/src/client/java/minicraft/entity/Entity.java
+++ b/src/client/java/minicraft/entity/Entity.java
@@ -5,7 +5,7 @@ import minicraft.core.Updater;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.level.Level;
 import minicraft.network.Network;
 import minicraft.util.Logging;
@@ -167,7 +167,7 @@ public abstract class Entity implements Tickable {
 	 * @param attackDir The direction to interact
 	 * @return If the interaction was successful
 	 */
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
 		return false;
 	}
 

--- a/src/client/java/minicraft/entity/ItemEntity.java
+++ b/src/client/java/minicraft/entity/ItemEntity.java
@@ -3,7 +3,7 @@ package minicraft.entity;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 
 import java.util.List;
 
@@ -11,7 +11,7 @@ public class ItemEntity extends Entity implements ClientTickable {
 	private int lifeTime; // The life time of this entity in the level
 	private double xa, ya, za; // The x, y, and z accelerations.
 	private double xx, yy, zz; // The x, y, and z coordinates; in double precision.
-	public Item item; // The item that this entity is based off of.
+	public ItemStack item; // The item that this entity is based off of.
 	private int time = 0; // Time it has lasted in the level
 
 	// Solely for multiplayer use.
@@ -24,7 +24,7 @@ public class ItemEntity extends Entity implements ClientTickable {
 	 * @param x position on map
 	 * @param y position on map
 	 */
-	public ItemEntity(Item item, int x, int y) {
+	public ItemEntity(ItemStack item, int x, int y) {
 		super(2, 2);
 
 		this.item = item.copy();
@@ -55,7 +55,7 @@ public class ItemEntity extends Entity implements ClientTickable {
 	 * @param ya y velocity
 	 * @param za z velocity?
 	 */
-	public ItemEntity(Item item, int x, int y, double zz, int lifetime, int time, double xa, double ya, double za) {
+	public ItemEntity(ItemStack item, int x, int y, double zz, int lifetime, int time, double xa, double ya, double za) {
 		this(item, x, y);
 		this.lifeTime = lifetime;
 		this.time = time;
@@ -128,8 +128,8 @@ public class ItemEntity extends Entity implements ClientTickable {
 			if (time / 6 % 2 == 0) return;
 		}
 
-		screen.render(x - 4, y - 4, item.sprite.getSprite(), 0, false, Color.get(0, 31)); // Item shadow
-		screen.render(x - 4, y - 4 - (int) zz, item.sprite); // Item
+		screen.render(x - 4, y - 4, item.getSprite().getSprite(), 0, false, Color.get(0, 31)); // Item shadow
+		screen.render(x - 4, y - 4 - (int) zz, item.getSprite()); // Item
 	}
 
 	@Override

--- a/src/client/java/minicraft/entity/furniture/Chest.java
+++ b/src/client/java/minicraft/entity/furniture/Chest.java
@@ -8,7 +8,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.item.Inventory;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.saveload.Load;
 import minicraft.screen.ContainerDisplay;
@@ -55,12 +55,12 @@ public class Chest extends Furniture implements ItemHolder {
 				//System.out.println(line);
 				String[] data = line.split(",");
 				if (!line.startsWith(":")) {
-					inventory.tryAdd(random, Integer.parseInt(data[0]), Items.get(data[1]), data.length < 3 ? 1 : Integer.parseInt(data[2]));
+					inventory.tryAdd(random, Integer.parseInt(data[0]), Items.getStackOf(data[1]), data.length < 3 ? 1 : Integer.parseInt(data[2]));
 				} else if (inventory.invSize() == 0) {
 					// Adds the "fallback" items to ensure there's some stuff
 					String[] fallbacks = line.substring(1).split(":");
 					for (String item : fallbacks) {
-						inventory.add(Items.get(item.split(",")[0]), Integer.parseInt(item.split(",")[1]));
+						inventory.add(Items.getStackOf(item.split(",")[0]), Integer.parseInt(item.split(",")[1]));
 					}
 				}
 			}
@@ -70,7 +70,7 @@ public class Chest extends Furniture implements ItemHolder {
 	}
 
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
 		if (inventory.invSize() == 0)
 			return super.interact(player, item, attackDir);
 		return false;
@@ -84,8 +84,8 @@ public class Chest extends Furniture implements ItemHolder {
 	@Override
 	public void die() {
 		if (level != null) {
-			List<Item> items = inventory.getItems();
-			level.dropItem(x, y, items.toArray(new Item[0]));
+			List<ItemStack> items = inventory.getItems();
+			level.dropItem(x, y, items.toArray(new ItemStack[0]));
 		}
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/furniture/Composter.java
+++ b/src/client/java/minicraft/entity/furniture/Composter.java
@@ -3,9 +3,8 @@ package minicraft.entity.furniture;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
-import minicraft.item.StackableItem;
 import org.jetbrains.annotations.Nullable;
 
 public class Composter extends Furniture {
@@ -22,21 +21,19 @@ public class Composter extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
 		if (compost == MAX_COMPOST) {
 			compost = 0;
-			StackableItem i = (StackableItem) Items.get("Fertilizer").copy();
-			i.count = 1;
-			player.getLevel().dropItem(x, y, i);
+			player.getLevel().dropItem(x, y, Items.getStackOf("Fertilizer"));
 			refreshStatus();
 			return true;
 		}
 
-		if (item instanceof StackableItem) {
+		if (item.isStackable()) {
 			// 100% compost as they are heavy food
 			if (item.getName().equalsIgnoreCase("Baked Potato") || item.getName().equalsIgnoreCase("Bread")) {
 				compost++;
-				((StackableItem) item).count--;
+				item.decrement(1);
 				refreshStatus();
 				return true;
 
@@ -46,7 +43,7 @@ public class Composter extends Furniture {
 				item.getName().equalsIgnoreCase("Potato") || item.getName().equalsIgnoreCase("Carrot")) {
 				if (random.nextInt(4) != 0) { // 75%
 					compost++;
-					((StackableItem) item).count--;
+					item.decrement(1);
 					refreshStatus();
 					return true;
 				}
@@ -56,7 +53,7 @@ public class Composter extends Furniture {
 				item.getName().equalsIgnoreCase("Wheat Seeds") || item.getName().equalsIgnoreCase("Grass Seeds")) {
 				if (random.nextInt(3) != 0) { // 66.7%
 					compost++;
-					((StackableItem) item).count--;
+					item.decrement(1);
 					refreshStatus();
 					return true;
 				}

--- a/src/client/java/minicraft/entity/furniture/DeathChest.java
+++ b/src/client/java/minicraft/entity/furniture/DeathChest.java
@@ -12,8 +12,7 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.item.Inventory;
-import minicraft.item.Item;
-import minicraft.item.StackableItem;
+import minicraft.item.ItemStack;
 
 public class DeathChest extends Chest {
 	private static LinkedSprite normalSprite = new LinkedSprite(SpriteType.Entity, "chest");
@@ -47,7 +46,7 @@ public class DeathChest extends Chest {
 		this();
 		this.x = player.x;
 		this.y = player.y;
-		for (Item i : player.getInventory().getItems()) {
+		for (ItemStack i : player.getInventory().getItems()) {
 			inventory.add(i.copy());
 		}
 	}
@@ -102,7 +101,7 @@ public class DeathChest extends Chest {
 	public void touchedBy(Entity other) {
 		if (other instanceof Player) {
 			Inventory playerInv = ((Player) other).getInventory();
-			for (Item i : inventory.getItems()) {
+			for (ItemStack i : inventory.getItems()) {
 				if (playerInv.add(i) != null) {
 					Game.notifications.add("Your inventory is full!");
 					return;

--- a/src/client/java/minicraft/entity/furniture/DungeonChest.java
+++ b/src/client/java/minicraft/entity/furniture/DungeonChest.java
@@ -9,9 +9,8 @@ import minicraft.entity.particle.TextParticle;
 import minicraft.gfx.Color;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
-import minicraft.item.StackableItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,15 +47,15 @@ public class DungeonChest extends Chest {
 
 	public boolean use(Player player) {
 		if (isLocked) {
-			boolean activeKey = player.activeItem != null && player.activeItem.equals(Items.get("Key"));
-			boolean invKey = player.getInventory().count(Items.get("key")) > 0;
+			boolean activeKey = player.activeItem != null && player.activeItem.equals(Items.getStackOf("Key"));
+			boolean invKey = player.getInventory().count(Items.getStackOf("key")) > 0;
 
 			if (activeKey || invKey) { // If the player has a key...
 				if (activeKey) { // Remove activeItem
-					StackableItem key = (StackableItem) player.activeItem;
-					key.count--;
+					ItemStack key = player.activeItem;
+					key.decrement(1);
 				} else { // Remove from inv
-					player.getInventory().removeItem(Items.get("key"));
+					player.getInventory().removeItem(Items.getStackOf("key"));
 				}
 
 				isLocked = false;
@@ -68,7 +67,7 @@ public class DungeonChest extends Chest {
 
 				// If this is the last chest.
 				if (level.chestCount == 0) {
-					level.dropItem(x, y, 5, Items.get("Gold Apple"));
+					level.dropItem(x, y, 5, Items.getStackOf("Gold Apple"));
 				}
 
 				return super.use(player); // the player unlocked the chest.
@@ -110,7 +109,7 @@ public class DungeonChest extends Chest {
 	}
 
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
 		if (!isLocked)
 			return super.interact(player, item, attackDir);
 		return false;

--- a/src/client/java/minicraft/entity/furniture/Furniture.java
+++ b/src/client/java/minicraft/entity/furniture/Furniture.java
@@ -7,7 +7,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.item.FurnitureItem;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PowerGloveItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,13 +97,13 @@ public class Furniture extends Entity {
 	 * @param player The player picking up the furniture.
 	 */
 	@Override
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
-		if (item instanceof PowerGloveItem) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof PowerGloveItem) {
 			Sound.play("monsterhurt");
 			remove();
-			if (player.activeItem != null && !(player.activeItem instanceof PowerGloveItem))
+			if (player.activeItem != null && !(player.activeItem.getItem() instanceof PowerGloveItem))
 				player.getLevel().dropItem(player.x, player.y, player.activeItem); // Put whatever item the player is holding into their inventory
-			player.activeItem = new FurnitureItem(this); // Make this the player's current item.
+			player.activeItem = new ItemStack(new FurnitureItem(this)); // Make this the player's current item.
 			return true;
 		}
 		return false;

--- a/src/client/java/minicraft/entity/furniture/KnightStatue.java
+++ b/src/client/java/minicraft/entity/furniture/KnightStatue.java
@@ -6,8 +6,9 @@ import minicraft.entity.Direction;
 import minicraft.entity.mob.ObsidianKnight;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class KnightStatue extends Furniture {
 	private int touches = 0; // >= 0
@@ -19,7 +20,7 @@ public class KnightStatue extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, Item heldItem, Direction attackDir) {
+	public boolean interact(Player player, @Nullable ItemStack heldItem, Direction attackDir) {
 		if (!ObsidianKnight.active) {
 			if (touches == 0) { // Touched the first time.
 				Game.notifications.add(Localization.getLocalized("minicraft.notifications.statue_tapped"));

--- a/src/client/java/minicraft/entity/furniture/Lantern.java
+++ b/src/client/java/minicraft/entity/furniture/Lantern.java
@@ -11,7 +11,7 @@ public class Lantern extends Furniture {
 		GOLD("Gold Lantern", 15, 4);
 
 		protected int light, offset;
-		protected String title;
+		public final String title;
 
 		Type(String title, int light, int offset) {
 			this.title = title;

--- a/src/client/java/minicraft/entity/furniture/Spawner.java
+++ b/src/client/java/minicraft/entity/furniture/Spawner.java
@@ -23,12 +23,13 @@ import minicraft.gfx.Point;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.item.FurnitureItem;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PotionType;
 import minicraft.item.PowerGloveItem;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.tinylog.Logger;
 
 import java.util.ArrayList;
@@ -173,9 +174,9 @@ public class Spawner extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 
 			Sound.play("monsterhurt");
 
@@ -203,11 +204,11 @@ public class Spawner extends Furniture {
 			return true;
 		}
 
-		if (item instanceof PowerGloveItem && Game.isMode("minicraft.settings.mode.creative")) {
+		if (item != null && item.getItem() instanceof PowerGloveItem && Game.isMode("minicraft.settings.mode.creative")) {
 			level.remove(this);
-			if (!(player.activeItem instanceof PowerGloveItem))
+			if (!(player.activeItem.getItem() instanceof PowerGloveItem))
 				player.getLevel().dropItem(player.x, player.y, player.activeItem);
-			player.activeItem = new FurnitureItem(this);
+			player.activeItem = new ItemStack(new FurnitureItem(this));
 			return true;
 		}
 

--- a/src/client/java/minicraft/entity/furniture/Tnt.java
+++ b/src/client/java/minicraft/entity/furniture/Tnt.java
@@ -11,17 +11,12 @@ import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PowerGloveItem;
-import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import minicraft.level.tile.Tiles;
 import minicraft.screen.AchievementsDisplay;
+import org.jetbrains.annotations.Nullable;
 
-import javax.swing.Timer;
-
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.List;
 
 public class Tnt extends Furniture {
@@ -99,8 +94,8 @@ public class Tnt extends Furniture {
 	}
 
 	@Override
-	public boolean interact(Player player, Item heldItem, Direction attackDir) {
-		if (heldItem instanceof PowerGloveItem) {
+	public boolean interact(Player player, @Nullable ItemStack heldItem, Direction attackDir) {
+		if (heldItem != null && heldItem.getItem() instanceof PowerGloveItem) {
 			if (!fuseLit) {
 				return super.interact(player, heldItem, attackDir);
 			}

--- a/src/client/java/minicraft/entity/mob/AirWizard.java
+++ b/src/client/java/minicraft/entity/mob/AirWizard.java
@@ -163,7 +163,7 @@ public class AirWizard extends EnemyMob {
 		if (players.length > 0) { // If the player is still here
 			for (Player p : players) {
 				p.addScore(100000); // Give the player 100K points.
-				dropItem(5, 10, Items.get("cloud ore")); // Drop cloud ore to guarantee respawn.
+				dropItem(5, 10, Items.getStackOf("cloud ore")); // Drop cloud ore to guarantee respawn.
 			}
 		}
 

--- a/src/client/java/minicraft/entity/mob/Cow.java
+++ b/src/client/java/minicraft/entity/mob/Cow.java
@@ -32,7 +32,7 @@ public class Cow extends PassiveMob {
 			max = 1;
 		}
 
-		dropItem(min, max, Items.get("leather"), Items.get("raw beef"));
+		dropItem(min, max, Items.getStackOf("leather"), Items.getStackOf("raw beef"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/Creeper.java
+++ b/src/client/java/minicraft/entity/mob/Creeper.java
@@ -11,7 +11,6 @@ import minicraft.gfx.Point;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.item.Items;
-import minicraft.level.tile.Tiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -165,7 +164,7 @@ public class Creeper extends EnemyMob {
 
 	public void die() {
 		// Only drop items if the creeper has not exploded
-		if (!fuseLit) dropItem(1, 4 - Settings.getIdx("diff"), Items.get("Gunpowder"));
+		if (!fuseLit) dropItem(1, 4 - Settings.getIdx("diff"), Items.getStackOf("Gunpowder"));
 		super.die();
 	}
 }

--- a/src/client/java/minicraft/entity/mob/Knight.java
+++ b/src/client/java/minicraft/entity/mob/Knight.java
@@ -22,13 +22,13 @@ public class Knight extends EnemyMob {
 
 	public void die() {
 		if (Settings.get("diff").equals("minicraft.settings.difficulty.easy"))
-			dropItem(1, 3, Items.get("shard"));
+			dropItem(1, 3, Items.getStackOf("shard"));
 		else
-			dropItem(0, 2, Items.get("shard")
+			dropItem(0, 2, Items.getStackOf("shard")
 			);
 
 		if (random.nextInt(24 / lvl / (Settings.getIdx("diff") + 1)) == 0)
-			dropItem(1, 1, Items.get("key"));
+			dropItem(1, 1, Items.getStackOf("key"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/MobAi.java
+++ b/src/client/java/minicraft/entity/mob/MobAi.java
@@ -10,7 +10,7 @@ import minicraft.gfx.Point;
 import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PotionType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
@@ -193,7 +193,7 @@ public abstract class MobAi extends Mob {
 	 * @param maxcount Most amount of items to add.
 	 * @param items Which items should be added.
 	 */
-	protected void dropItem(int mincount, int maxcount, Item... items) {
+	protected void dropItem(int mincount, int maxcount, ItemStack... items) {
 		int count = random.nextInt(maxcount - mincount + 1) + mincount;
 		for (int i = 0; i < count; i++)
 			level.dropItem(x, y, items);

--- a/src/client/java/minicraft/entity/mob/ObsidianKnight.java
+++ b/src/client/java/minicraft/entity/mob/ObsidianKnight.java
@@ -249,8 +249,8 @@ public class ObsidianKnight extends EnemyMob {
 		if (players.length > 0) { // If the player is still here
 			for (Player p : players) {
 				p.addScore(300000); // Give the player 300K points.
-				dropItem(15, 25, Items.get("shard"));
-				dropItem(1, 1, Items.get("Obsidian Heart")); // Drop it's precious item.
+				dropItem(15, 25, Items.getStackOf("shard"));
+				dropItem(1, 1, Items.getStackOf("Obsidian Heart")); // Drop it's precious item.
 			}
 		}
 

--- a/src/client/java/minicraft/entity/mob/Pig.java
+++ b/src/client/java/minicraft/entity/mob/Pig.java
@@ -29,7 +29,7 @@ public class Pig extends PassiveMob {
 			max = 2;
 		}
 
-		dropItem(min, max, Items.get("raw pork"));
+		dropItem(min, max, Items.getStackOf("raw pork"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/Sheep.java
+++ b/src/client/java/minicraft/entity/mob/Sheep.java
@@ -1,13 +1,13 @@
 package minicraft.entity.mob;
 
 import minicraft.item.DyeItem;
+import minicraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import minicraft.core.io.Settings;
 import minicraft.entity.Direction;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
-import minicraft.item.Item;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -77,17 +77,17 @@ public class Sheep extends PassiveMob {
 		}
 	}
 
-	public boolean interact(Player player, @Nullable Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			if (!cut && ((ToolItem) item).type == ToolType.Shears) {
+	public boolean interact(Player player, @Nullable ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof ToolItem) {
+			if (!cut && ((ToolItem) item.getItem()).type == ToolType.Shears) {
 				cut = true;
-				dropItem(1, 3, Items.get(color.toString().replace('_', ' ') + " Wool"));
-				((ToolItem) item).payDurability();
+				dropItem(1, 3, Items.getStackOf(color.toString().replace('_', ' ') + " Wool"));
+				((ToolItem) item.getItem()).payDurability(item);
 				return true;
 			}
-		} else if (item instanceof DyeItem) {
-			color = ((DyeItem) item).color;
-			((DyeItem) item).count--;
+		} else if (item != null && item.getItem() instanceof DyeItem) {
+			color = ((DyeItem) item.getItem()).color;
+			item.decrement(1);
 			return true;
 		}
 		return false;
@@ -108,8 +108,8 @@ public class Sheep extends PassiveMob {
 			max = 2;
 		}
 
-		if (!cut) dropItem(min, max, Items.get(color.toString().replace('_', ' ') + " Wool"));
-		dropItem(min, max, Items.get("Raw Beef"));
+		if (!cut) dropItem(min, max, Items.getStackOf(color.toString().replace('_', ' ') + " Wool"));
+		dropItem(min, max, Items.getStackOf("Raw Beef"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/Skeleton.java
+++ b/src/client/java/minicraft/entity/mob/Skeleton.java
@@ -59,11 +59,11 @@ public class Skeleton extends EnemyMob {
 		int rand = random.nextInt(diffrands[diff]);
 
 		if (rand <= diffvals[diff])
-			level.dropItem(x, y, count, Items.get("bone"), Items.get("arrow"));
+			level.dropItem(x, y, count, Items.getStackOf("bone"), Items.getStackOf("arrow"));
 		else if (diff == 0 && rand >= 19) // Rare chance of 10 arrows on easy mode
-			level.dropItem(x, y, 10, Items.get("arrow"));
+			level.dropItem(x, y, 10, Items.getStackOf("arrow"));
 		else
-			level.dropItem(x, y, bookcount, Items.get("Antidious"), Items.get("arrow"));
+			level.dropItem(x, y, bookcount, Items.getStackOf("Antidious"), Items.getStackOf("arrow"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/Slime.java
+++ b/src/client/java/minicraft/entity/mob/Slime.java
@@ -70,7 +70,7 @@ public class Slime extends EnemyMob {
 	}
 
 	public void die() {
-		dropItem(1, Game.isMode("minicraft.settings.mode.score") ? 2 : 4 - Settings.getIdx("diff"), Items.get("slime"));
+		dropItem(1, Game.isMode("minicraft.settings.mode.score") ? 2 : 4 - Settings.getIdx("diff"), Items.getStackOf("slime"));
 
 		super.die(); // Parent death call
 	}

--- a/src/client/java/minicraft/entity/mob/Snake.java
+++ b/src/client/java/minicraft/entity/mob/Snake.java
@@ -27,10 +27,10 @@ public class Snake extends EnemyMob {
 
 	public void die() {
 		int num = Settings.get("diff").equals("minicraft.settings.difficulty.hard") ? 1 : 0;
-		dropItem(num, num + 1, Items.get("scale"));
+		dropItem(num, num + 1, Items.getStackOf("scale"));
 
 		if (random.nextInt(24 / lvl / (Settings.getIdx("diff") + 1)) == 0)
-			dropItem(1, 1, Items.get("key"));
+			dropItem(1, 1, Items.getStackOf("key"));
 
 		super.die();
 	}

--- a/src/client/java/minicraft/entity/mob/Zombie.java
+++ b/src/client/java/minicraft/entity/mob/Zombie.java
@@ -21,27 +21,27 @@ public class Zombie extends EnemyMob {
 	}
 
 	public void die() {
-		if (Settings.get("diff").equals("minicraft.settings.difficulty.easy")) dropItem(2, 4, Items.get("cloth"));
-		if (Settings.get("diff").equals("minicraft.settings.difficulty.normal")) dropItem(1, 3, Items.get("cloth"));
-		if (Settings.get("diff").equals("minicraft.settings.difficulty.hard")) dropItem(1, 2, Items.get("cloth"));
+		if (Settings.get("diff").equals("minicraft.settings.difficulty.easy")) dropItem(2, 4, Items.getStackOf("cloth"));
+		if (Settings.get("diff").equals("minicraft.settings.difficulty.normal")) dropItem(1, 3, Items.getStackOf("cloth"));
+		if (Settings.get("diff").equals("minicraft.settings.difficulty.hard")) dropItem(1, 2, Items.getStackOf("cloth"));
 
 		if (random.nextInt(60) == 2) {
-			level.dropItem(x, y, Items.get("iron"));
+			level.dropItem(x, y, Items.getStackOf("iron"));
 		}
 
 		if (random.nextInt(40) == 19) {
 			int rand = random.nextInt(3);
 			if (rand == 0) {
-				level.dropItem(x, y, Items.get("green clothes"));
+				level.dropItem(x, y, Items.getStackOf("green clothes"));
 			} else if (rand == 1) {
-				level.dropItem(x, y, Items.get("red clothes"));
+				level.dropItem(x, y, Items.getStackOf("red clothes"));
 			} else if (rand == 2) {
-				level.dropItem(x, y, Items.get("blue clothes"));
+				level.dropItem(x, y, Items.getStackOf("blue clothes"));
 			}
 		}
 
 		if (random.nextInt(100) < 4) {
-			level.dropItem(x, y, Items.get("Potato"));
+			level.dropItem(x, y, Items.getStackOf("Potato"));
 		}
 
 		super.die();

--- a/src/client/java/minicraft/entity/vehicle/Boat.java
+++ b/src/client/java/minicraft/entity/vehicle/Boat.java
@@ -1,6 +1,5 @@
 package minicraft.entity.vehicle;
 
-import minicraft.core.Game;
 import minicraft.core.Updater;
 import minicraft.core.io.Sound;
 import minicraft.entity.Direction;
@@ -89,7 +88,7 @@ public class Boat extends Entity implements PlayerRideable {
 
 	@Override
 	public void die() {
-		level.dropItem(x, y, Items.get("Boat"));
+		level.dropItem(x, y, Items.getStackOf("Boat"));
 		Sound.play("monsterhurt");
 		super.die();
 	}

--- a/src/client/java/minicraft/item/ArmorItem.java
+++ b/src/client/java/minicraft/item/ArmorItem.java
@@ -6,7 +6,6 @@ import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -28,34 +27,26 @@ public class ArmorItem extends StackableItem {
 	private final int staminaCost;
 	public final int level;
 
-	private ArmorItem(String name, LinkedSprite sprite, float health, int level) {
-		this(name, sprite, 1, health, level);
-	}
-
-	private ArmorItem(String name, LinkedSprite sprite, int count, float health, int level) {
-		super(name, sprite, count);
+	private ArmorItem(String name, LinkedSprite sprite,  float health, int level) {
+		super(name, sprite);
 		this.armor = health;
 		this.level = level;
 		staminaCost = 9;
 	}
 
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		boolean success = false;
 		if (player.curArmor == null && player.payStamina(staminaCost)) {
-			player.curArmor = this; // Set the current armor being worn to this.
+			player.curArmor = stack; // Set the current armor being worn to this.
 			player.armor = (int) (armor * Player.maxArmor); // Armor is how many hits are left
 			success = true;
 		}
 
-		return super.interactOn(success);
+		return super.interactOn(success, stack);
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull ArmorItem copy() {
-		return new ArmorItem(getName(), sprite, count, armor, level);
 	}
 }

--- a/src/client/java/minicraft/item/BookItem.java
+++ b/src/client/java/minicraft/item/BookItem.java
@@ -6,52 +6,46 @@ import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
+import minicraft.item.component.ComponentMap;
+import minicraft.item.component.ComponentTypes;
+import minicraft.item.component.type.BookContentComponent;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 import minicraft.screen.BookDisplay;
 import minicraft.util.BookData;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
 public class BookItem extends Item {
 
 	protected static ArrayList<Item> getAllInstances() {
-		ArrayList<Item> items = new ArrayList<Item>();
+		ArrayList<Item> items = new ArrayList<>();
 		items.add(new BookItem("Book", new LinkedSprite(SpriteType.Item, "book"), () -> Localization.getLocalized("minicraft.displays.book.default_book")));
 		items.add(new BookItem("Antidious", new LinkedSprite(SpriteType.Item, "antidious_book"), () -> BookData.antVenomBook.collect(), true));
 		return items;
 	}
 
 	@FunctionalInterface
-	public static interface BookContent {
-		public abstract String collect();
+	public interface BookContent {
+		String collect();
 	}
-
-	protected BookContent book; // TODO this is not saved yet; it could be, for editable books.
-	private final boolean hasTitlePage;
 
 	private BookItem(String title, LinkedSprite sprite, BookContent book) {
 		this(title, sprite, book, false);
 	}
 
 	private BookItem(String title, LinkedSprite sprite, BookContent book, boolean hasTitlePage) {
-		super(title, sprite);
-		this.book = book;
-		this.hasTitlePage = hasTitlePage;
+		super(title, sprite, ComponentMap.builder().add(ComponentTypes.BOOK_CONTENT, new BookContentComponent(book, hasTitlePage)).build());
 	}
 
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
-		Game.setDisplay(new BookDisplay(book.collect(), hasTitlePage));
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
+		BookContentComponent component = stack.get(ComponentTypes.BOOK_CONTENT);
+		Game.setDisplay(new BookDisplay(component.content().collect(), component.hasTitlePage()));
 		return true;
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull BookItem copy() {
-		return new BookItem(getName(), sprite, book, hasTitlePage);
 	}
 }

--- a/src/client/java/minicraft/item/ClothingItem.java
+++ b/src/client/java/minicraft/item/ClothingItem.java
@@ -8,7 +8,6 @@ import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -30,42 +29,33 @@ public class ClothingItem extends StackableItem {
 		return items;
 	}
 
-	private int playerCol;
+	private final int playerCol;
 
 	private ClothingItem(String name, LinkedSprite sprite, int pcol) {
-		this(name, 1, sprite, pcol);
-	}
-
-	private ClothingItem(String name, int count, LinkedSprite sprite, int pcol) {
-		super(name, sprite, count);
+		super(name, sprite);
 		playerCol = pcol;
 	}
 
 	// Put on clothes
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		if (player.shirtColor == playerCol) {
 			return false;
 		} else {
 			if (!Game.isMode("minicraft.settings.mode.creative")) {
-				ClothingItem lastClothing = (ClothingItem) getAllInstances().stream().filter(i -> i instanceof ClothingItem && ((ClothingItem) i).playerCol == player.shirtColor)
+				Item lastClothing = getAllInstances().stream().filter(i -> i instanceof ClothingItem && ((ClothingItem) i).playerCol == player.shirtColor)
 					.findAny().orElse(null);
 				if (lastClothing == null)
-					lastClothing = (ClothingItem) Items.get("Reg Clothes");
-				lastClothing = lastClothing.copy();
-				lastClothing.count = 1;
-				player.tryAddToInvOrDrop(lastClothing);
+					lastClothing = Items.getStackOf("Reg Clothes").getItem();
+
+				player.tryAddToInvOrDrop(new ItemStack(lastClothing));
 			}
 			player.shirtColor = playerCol;
-			return super.interactOn(true);
+			return super.interactOn(true, stack);
 		}
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull ClothingItem copy() {
-		return new ClothingItem(getName(), count, sprite, playerCol);
 	}
 }

--- a/src/client/java/minicraft/item/DyeItem.java
+++ b/src/client/java/minicraft/item/DyeItem.java
@@ -2,7 +2,6 @@ package minicraft.item;
 
 import minicraft.gfx.SpriteLinker;
 import minicraft.util.MyUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -49,10 +48,5 @@ public class DyeItem extends StackableItem {
 		DyeColor(int color) {
 			this.color = color;
 		}
-	}
-
-	@Override
-	public @NotNull DyeItem copy() {
-		return new DyeItem(getName(), sprite, color);
 	}
 }

--- a/src/client/java/minicraft/item/EntitySummonItem.java
+++ b/src/client/java/minicraft/item/EntitySummonItem.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class EntitySummonItem extends StackableItem {
 	protected static ArrayList<Item> getAllInstances() {
@@ -28,18 +27,13 @@ public class EntitySummonItem extends StackableItem {
 	}
 
 	@Override
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		level.add(entitySupplier.apply(attackDir), player.x + 12 * attackDir.getX(), player.y + 12 * attackDir.getY());
 		return true;
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	@Override
-	public @NotNull StackableItem copy() {
-		return new EntitySummonItem(getName(), sprite, entitySupplier);
 	}
 }

--- a/src/client/java/minicraft/item/FishingRodItem.java
+++ b/src/client/java/minicraft/item/FishingRodItem.java
@@ -5,10 +5,11 @@ import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
+import minicraft.item.component.ComponentMap;
+import minicraft.item.component.ComponentTypes;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 import minicraft.level.tile.Tiles;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -25,10 +26,9 @@ public class FishingRodItem extends Item {
 		return items;
 	}
 
-	private int uses = 0; // The more uses, the higher the chance of breaking
-	public int level; // The higher the level the lower the chance of breaking
+	public final int level; // The higher the level the lower the chance of breaking
 
-	private Random random = new Random();
+	private final Random random = new Random();
 
 	/* These numbers are a bit confusing, so here's an explanation
 	 * If you want to know the percent chance of a category (let's say tool, which is third)
@@ -49,7 +49,7 @@ public class FishingRodItem extends Item {
 
 	public FishingRodItem(int level) {
 		super(LEVEL_NAMES[level] + " Fishing Rod", new LinkedSprite(SpriteType.Item,
-			LEVEL_NAMES[level].toLowerCase().replace("wood", "wooden") + "_fishing_rod"));
+			LEVEL_NAMES[level].toLowerCase().replace("wood", "wooden") + "_fishing_rod"), ComponentMap.builder().add(ComponentTypes.FISHING_ROD_USES, 0).build());
 		this.level = level;
 	}
 
@@ -58,9 +58,9 @@ public class FishingRodItem extends Item {
 	}
 
 	@Override
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		if (tile == Tiles.get("water") && !player.isSwimming()) { // Make sure not to use it if swimming
-			uses++;
+			stack.put(ComponentTypes.FISHING_ROD_USES, stack.get(ComponentTypes.FISHING_ROD_USES) + 1);
 			player.isFishing = true;
 			player.fishingLevel = this.level;
 			return true;
@@ -70,23 +70,16 @@ public class FishingRodItem extends Item {
 	}
 
 	@Override
-	public boolean canAttack() {
+	public boolean canAttack(ItemStack stack) {
 		return false;
 	}
 
 	@Override
-	public boolean isDepleted() {
-		if (random.nextInt(100) > 120 - uses + level * 6) { // Breaking is random, the lower the level, and the more times you use it, the higher the chance
+	public boolean isDepleted(ItemStack stack) {
+		if (random.nextInt(100) > 120 - stack.get(ComponentTypes.FISHING_ROD_USES) + level * 6) { // Breaking is random, the lower the level, and the more times you use it, the higher the chance
 			Game.notifications.add("Your Fishing rod broke.");
 			return true;
 		}
 		return false;
-	}
-
-	@Override
-	public @NotNull Item copy() {
-		FishingRodItem item = new FishingRodItem(this.level);
-		item.uses = this.uses;
-		return item;
 	}
 }

--- a/src/client/java/minicraft/item/FoodItem.java
+++ b/src/client/java/minicraft/item/FoodItem.java
@@ -6,7 +6,6 @@ import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -33,33 +32,25 @@ public class FoodItem extends StackableItem {
 	private static final int staminaCost = 2; // The amount of stamina it costs to consume the food.
 
 	private FoodItem(String name, LinkedSprite sprite, int feed) {
-		this(name, sprite, 1, feed);
-	}
-
-	private FoodItem(String name, LinkedSprite sprite, int count, int feed) {
-		super(name, sprite, count);
+		super(name, sprite);
 		this.feed = feed;
 	}
 
 	/**
 	 * What happens when the player uses the item on a tile
 	 */
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		boolean success = false;
-		if (count > 0 && player.hunger < Player.maxHunger && player.payStamina(staminaCost)) { // If the player has hunger to fill, and stamina to pay...
+		if (stack.getCount() > 0 && player.hunger < Player.maxHunger && player.payStamina(staminaCost)) { // If the player has hunger to fill, and stamina to pay...
 			player.hunger = Math.min(player.hunger + feed, Player.maxHunger); // Restore the hunger
 			success = true;
 		}
 
-		return super.interactOn(success);
+		return super.interactOn(success, stack);
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull FoodItem copy() {
-		return new FoodItem(getName(), sprite, count, feed);
 	}
 }

--- a/src/client/java/minicraft/item/HeartItem.java
+++ b/src/client/java/minicraft/item/HeartItem.java
@@ -6,7 +6,6 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteLinker;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -20,15 +19,11 @@ public class HeartItem extends StackableItem {
 		return items;
 	}
 
-	private int health; // The amount of health to increase by.
-	private int staminaCost; // The amount of stamina it costs to consume.
+	private final int health; // The amount of health to increase by.
+	private final int staminaCost; // The amount of stamina it costs to consume.
 
 	private HeartItem(String name, SpriteLinker.LinkedSprite sprite, int health) {
-		this(name, sprite, 1, health);
-	}
-
-	private HeartItem(String name, SpriteLinker.LinkedSprite sprite, int count, int health) {
-		super(name, sprite, count);
+		super(name, sprite);
 		this.health = health;
 		staminaCost = 7;
 	}
@@ -36,8 +31,8 @@ public class HeartItem extends StackableItem {
 	/**
 	 * What happens when the player uses the item on a tile
 	 */
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
-		boolean success = false;
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
+		boolean success;
 
 		if ((Player.baseHealth + Player.extraHealth) < Player.maxHealth) {
 			Player.extraHealth += health; // Permanent increase of health by health variable (Basically 5)
@@ -48,15 +43,11 @@ public class HeartItem extends StackableItem {
 			return false;
 		}
 
-		return super.interactOn(success);
+		return super.interactOn(success, stack);
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull HeartItem copy() {
-		return new HeartItem(getName(), sprite, count, health);
 	}
 }

--- a/src/client/java/minicraft/item/Item.java
+++ b/src/client/java/minicraft/item/Item.java
@@ -8,34 +8,48 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
+import minicraft.item.component.ComponentMap;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 
 public abstract class Item {
 
 	/* Note: Most of the stuff in the class is expanded upon in StackableItem/PowerGloveItem/FurnitureItem/etc */
 
 	private final String name;
-	public LinkedSprite sprite;
+	private LinkedSprite sprite;
+
+	private final ComponentMap components;
 
 	public boolean used_pending = false; // This is for multiplayer, when an item has been used, and is pending server response as to the outcome, this is set to true so it cannot be used again unless the server responds that the item wasn't used. Which should basically replace the item anyway, soo... yeah. this never gets set back.
 
+	public int maxCount = 1;
+
 	protected Item(String name) {
+		this(name, new ComponentMap());
+	}
+
+	protected Item(String name, ComponentMap components) {
 		sprite = SpriteLinker.missingTexture(SpriteType.Item);
 		this.name = name;
+		this.components = components;
 	}
 
 	protected Item(String name, LinkedSprite sprite) {
+		this(name, sprite, new ComponentMap());
+	}
+
+	protected Item(String name, LinkedSprite sprite, ComponentMap components) {
 		this.name = name;
 		this.sprite = sprite;
+		this.components = components;
 	}
 
 	/**
 	 * Renders an item on the HUD
 	 */
-	public void renderHUD(Screen screen, int x, int y, int fontColor) {
-		String dispName = getDisplayName();
+	public void renderHUD(Screen screen, int x, int y, int fontColor, ItemStack stack) {
+		String dispName = getDisplayName(stack);
 		screen.render(x, y, sprite);
 		Font.drawBackground(dispName, screen, x + 8, y, fontColor);
 	}
@@ -43,21 +57,32 @@ public abstract class Item {
 	/**
 	 * Determines what happens when the player interacts with a tile
 	 */
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		return false;
+	}
+
+	/**
+	 * Returns the Item default components
+	 */
+	public ComponentMap getComponents() {
+		return this.components;
+	}
+
+	public LinkedSprite getSprite(ItemStack stack) {
+		return this.sprite;
 	}
 
 	/**
 	 * Returning true causes this item to be removed from the player's active item slot
 	 */
-	public boolean isDepleted() {
+	public boolean isDepleted(ItemStack stack) {
 		return false;
 	}
 
 	/**
 	 * Returns if the item can attack mobs or not
 	 */
-	public boolean canAttack() {
+	public boolean canAttack(ItemStack stack) {
 		return false;
 	}
 
@@ -76,8 +101,8 @@ public abstract class Item {
 	/**
 	 * This returns a copy of this item, in all necessary detail.
 	 */
-	@NotNull
-	public abstract Item copy();
+// 	@NotNull
+// 	public abstract Item copy();
 
 	@Override
 	public String toString() {
@@ -87,7 +112,7 @@ public abstract class Item {
 	/**
 	 * Gets the necessary data to send over a connection. This data should always be directly input-able into Items.get() to create a valid item with the given properties.
 	 */
-	public String getData() {
+	public String getData(ItemStack stack) {
 		return name;
 	}
 
@@ -103,11 +128,11 @@ public abstract class Item {
 	}
 
 	// Returns the String that should be used to display this item in a menu or list.
-	public String getDisplayName() {
+	public String getDisplayName(ItemStack stack) {
 		return " " + Localization.getLocalized(getName());
 	}
 
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return true;
 	}
 }

--- a/src/client/java/minicraft/item/ItemStack.java
+++ b/src/client/java/minicraft/item/ItemStack.java
@@ -1,0 +1,159 @@
+package minicraft.item;
+
+import minicraft.entity.Direction;
+import minicraft.entity.mob.Player;
+import minicraft.gfx.Screen;
+import minicraft.gfx.SpriteLinker;
+import minicraft.item.component.ComponentMap;
+import minicraft.item.component.ComponentType;
+import minicraft.item.component.ComponentTypes;
+import minicraft.level.Level;
+import minicraft.level.tile.Tile;
+
+public class ItemStack {
+	public static final ItemStack EMPTY = new ItemStack(null, 0);
+
+	private final Item item;
+	private int count;
+	private final ComponentMap components;
+
+	public ItemStack(Item item) {
+		this(item, 1);
+	}
+
+	public ItemStack(Item item, int count) {
+		this(item, count, item == null ? new ComponentMap() : new ComponentMap(item.getComponents()));
+	}
+
+	public ItemStack(Item item, int count, ComponentMap components) {
+		this.item = item;
+		this.components = components;
+		this.setCount(count);
+	}
+
+	public ComponentMap getComponents() {
+		return this.components;
+	}
+
+	public <T> void put(ComponentType<T> type, T value) {
+		this.components.put(type, value);
+	}
+
+	public <T> T get(ComponentType<T> type) {
+		return this.components.get(type);
+	}
+
+	public <T> T getOrDefault(ComponentType<T> type, T fallback) {
+		return this.components.getOrDefault(type, fallback);
+	}
+
+	public <T> boolean has(ComponentType<T> type) {
+		return this.components.has(type);
+	}
+
+	public Item getItem() {
+		return this.item;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends Item> T getItemAs() {
+		return (T) this.item;
+	}
+
+	public int getDurability() {
+		return this.getOrDefault(ComponentTypes.DURABILITY, 0);
+	}
+
+	public void setDurability(int durability) {
+		this.put(ComponentTypes.DURABILITY, Math.max(0, durability));
+	}
+
+	public <T extends Item> boolean isOf(Class<T> clazz) {
+		return this.getItem().getClass() == clazz;
+	}
+
+	public boolean canAttack() {
+		return this.item.canAttack(this);
+	}
+
+	public int getCount() {
+		return this.count;
+	}
+
+	public void setCount(int count) {
+		this.count = Math.max(0, count);
+	}
+
+	public void decrement(int amount) {
+		this.setCount(this.count - amount);
+	}
+
+	public void increment(int amount) {
+		this.setCount(this.count + amount);
+	}
+
+	public boolean isStackable() {
+		return this.item.maxCount > 1;
+	}
+
+	public String getName() {
+		return this.item.getName();
+	}
+
+	public String getDescription() {
+		return this.item.getDescription();
+	}
+
+	public int getMaxCount() {
+		return this.item.maxCount;
+	}
+
+	public void renderHUD(Screen screen, int x, int y, int fontColor) {
+		this.item.renderHUD(screen, x, y, fontColor, this);
+	}
+
+	public String getData() {
+		return this.item.getData(this);
+	}
+
+	public SpriteLinker.LinkedSprite getSprite() {
+		return this.item.getSprite(this);
+	}
+
+	public boolean interactsWithWorld() {
+		return this.item.interactsWithWorld(this);
+	}
+
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+		return this.item.interactOn(tile, level, xt, yt, player, attackDir, this);
+	}
+
+	public boolean isDepleted() {
+		return this.item == null || this.item.isDepleted(this) || this.count <= 0;
+	}
+
+	public boolean isEmpty() {
+		return this == EMPTY || this.item == null || this.count <= 0;
+	}
+
+	public ItemStack copy() {
+		return new ItemStack(this.item, this.count, this.components.copy());
+	}
+
+	@Override
+	public boolean equals(Object item) {
+		if (!(item instanceof ItemStack)) return false;
+		ItemStack stack = (ItemStack) item;
+		return this.item != null && this.item.equals(stack.item);
+	}
+
+	@Override
+	public int hashCode() {
+		return this.item.getName().hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return this.item.toString();
+	}
+}

--- a/src/client/java/minicraft/item/Items.java
+++ b/src/client/java/minicraft/item/Items.java
@@ -1,5 +1,7 @@
 package minicraft.item;
 
+import minicraft.item.component.ComponentTypes;
+import minicraft.item.component.type.WateringCanComponent;
 import minicraft.util.Logging;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -57,14 +59,14 @@ public class Items {
 	 * fetches an item from the list given its name.
 	 */
 	@NotNull
-	public static Item get(String name) {
-		Item i = get(name, false);
-		if (i == null) return new UnknownItem("NULL"); // Technically shouldn't ever happen
+	public static ItemStack getStackOf(String name) {
+		ItemStack i = getStackOf(name, false);
+		if (i == null) return new ItemStack(new UnknownItem("NULL")); // Technically shouldn't ever happen
 		return i;
 	}
 
 	@Nullable
-	public static Item get(String name, boolean allowNull) {
+	public static ItemStack getStackOf(String name, boolean allowNull) {
 		name = name.toUpperCase();
 		//System.out.println("fetching name: \"" + name + "\"");
 		int data = 1;
@@ -91,41 +93,41 @@ public class Items {
 			if (allowNull) return null;
 			else {
 				Logging.ITEMS.warn("Items.get passed argument \"null\" when null is not allowed; returning UnknownItem.");
-				return new UnknownItem("NULL");
+				return new ItemStack(new UnknownItem("NULL"));
 			}
 		}
 
 		if (name.equals("UNKNOWN"))
-			return new UnknownItem("BLANK");
+			return new ItemStack(new UnknownItem("BLANK"));
 
-		Item i = null;
+		ItemStack i = null;
 		for (Item cur : items) {
 			if (cur.getName().equalsIgnoreCase(name)) {
-				i = cur;
+				i = new ItemStack(cur);
 				break;
 			}
 		}
 
 		if (i != null) {
 			i = i.copy();
-			if (i instanceof StackableItem)
-				((StackableItem) i).count = data;
-			if (i instanceof ToolItem && hadUnderscore)
-				((ToolItem) i).dur = data;
-			if (i instanceof WateringCanItem)
-				((WateringCanItem) i).content = data;
+			if (i.getItem() instanceof StackableItem)
+				i.setCount(data);
+			if (i.getItem() instanceof ToolItem && hadUnderscore)
+				i.setDurability(data);
+			if (i.getItem() instanceof WateringCanItem)
+				i.put(ComponentTypes.WATERING_CAN, new WateringCanComponent(data, 0));
 			return i;
 		} else {
 			Logging.ITEMS.error("Requested invalid item with name: '{}'", name);
-			return new UnknownItem(name);
+			return new ItemStack(new UnknownItem(name));
 		}
 	}
 
-	public static Item arrowItem = get("arrow");
+	public static Item arrowItem = getStackOf("arrow").getItem();
 
-	public static int getCount(Item item) {
-		if (item instanceof StackableItem) {
-			return ((StackableItem) item).count;
+	public static int getCount(ItemStack item) {
+		if (item.isStackable()) {
+			return item.getCount();
 		} else if (item != null) {
 			return 1;
 		} else {
@@ -141,7 +143,7 @@ public class Items {
 		CreativeModeInventory() {
 			unlimited = true;
 			items.forEach(i -> {
-				if (!(i instanceof PowerGloveItem)) add(i.copy());
+				if (!(i instanceof PowerGloveItem)) add(new ItemStack(i));
 			});
 		}
 	}

--- a/src/client/java/minicraft/item/PotionItem.java
+++ b/src/client/java/minicraft/item/PotionItem.java
@@ -8,7 +8,6 @@ import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 import minicraft.screen.AchievementsDisplay;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -23,29 +22,25 @@ public class PotionItem extends StackableItem {
 		return items;
 	}
 
-	public PotionType type;
+	public final PotionType type;
 
 	private PotionItem(PotionType type) {
-		this(type, 1);
-	}
-
-	private PotionItem(PotionType type, int count) {
-		super(type.name, new LinkedSprite(SpriteType.Item, "potion").setColor(type.dispColor), count);
+		super(type.name, new LinkedSprite(SpriteType.Item, "potion").setColor(type.dispColor));
 		this.type = type;
 	}
 
 	// The return value is used to determine if the potion was used, which means being discarded.
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		if (type.equals(PotionType.Lava)) {
 			AchievementsDisplay.setAchievement("minicraft.achievement.lava", true);
 		}
-		return interactOn(applyPotion(player, type, true), player);
+		return interactOn(applyPotion(player, type, true), player, stack);
 	}
 
-	protected boolean interactOn(boolean subClassSuccess, Player player) {
+	protected boolean interactOn(boolean subClassSuccess, Player player, ItemStack stack) {
 		if (subClassSuccess && !Game.isMode("minicraft.settings.mode.creative"))
-			player.tryAddToInvOrDrop(Items.get("glass bottle"));
-		return super.interactOn(subClassSuccess);
+			player.tryAddToInvOrDrop(Items.getStackOf("glass bottle"));
+		return super.interactOn(subClassSuccess, stack);
 	}
 
 	/// Only ever called to load from file
@@ -79,11 +74,7 @@ public class PotionItem extends StackableItem {
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull PotionItem copy() {
-		return new PotionItem(type, count);
 	}
 }

--- a/src/client/java/minicraft/item/PowerGloveItem.java
+++ b/src/client/java/minicraft/item/PowerGloveItem.java
@@ -1,14 +1,7 @@
 package minicraft.item;
 
-import org.jetbrains.annotations.NotNull;
-
 public class PowerGloveItem extends Item {
-
 	public PowerGloveItem() {
 		super("Power Glove");
-	}
-
-	public @NotNull PowerGloveItem copy() {
-		return new PowerGloveItem();
 	}
 }

--- a/src/client/java/minicraft/item/Recipe.java
+++ b/src/client/java/minicraft/item/Recipe.java
@@ -4,7 +4,6 @@ import minicraft.core.Game;
 import minicraft.entity.mob.Player;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -39,8 +38,8 @@ public class Recipe {
 		}
 	}
 
-	public Item getProduct() {
-		return Items.get(product);
+	public ItemStack getProduct() {
+		return Items.getStackOf(product);
 	}
 
 	public Map<String, Integer> getCosts() {
@@ -68,7 +67,7 @@ public class Recipe {
 
 		for (String cost : costs.keySet().toArray(new String[0])) { // Cycles through the costs list
 			/// This method ONLY WORKS if costs does not contain two elements such that inventory.count will count an item it contains as matching more than once.
-			if (player.getInventory().count(Items.get(cost)) < costs.get(cost)) {
+			if (player.getInventory().count(Items.getStackOf(cost)) < costs.get(cost)) {
 				return false;
 			}
 		}
@@ -83,13 +82,13 @@ public class Recipe {
 		if (!Game.isMode("minicraft.settings.mode.creative")) {
 			// Remove the cost items from the inventory.
 			for (String cost : costs.keySet().toArray(new String[0])) {
-				player.getInventory().removeItems(Items.get(cost), costs.get(cost));
+				player.getInventory().removeItems(Items.getStackOf(cost), costs.get(cost));
 			}
 		}
 
 		// Rdd the crafted items.
 		for (int i = 0; i < amount; i++) {
-			Item product = getProduct();
+			ItemStack product = getProduct();
 			if (player.getInventory().add(product) != null)
 				player.getLevel().dropItem(player.x, player.y, product);
 		}

--- a/src/client/java/minicraft/item/Recipes.java
+++ b/src/client/java/minicraft/item/Recipes.java
@@ -1,6 +1,7 @@
 package minicraft.item;
 
 import minicraft.entity.furniture.Bed;
+import minicraft.item.component.ComponentTypes;
 import minicraft.level.tile.FlowerTile;
 import minicraft.saveload.Save;
 import org.json.JSONArray;
@@ -290,11 +291,11 @@ public class Recipes {
 		resolvedRecipes.put(new Recipe("magenta dye_4", "red dye_2", "white dye_1", "blue dye_1"), "magenta_dye_from_blue_red_white_dye");
 		resolvedRecipes.put(new Recipe("magenta dye_4", "pink dye_1", "red dye_1", "blue dye_1"), "magenta_dye_from_blue_red_pink");
 		Function<Recipe, String> recipeNameFixer = recipe -> { // This is applied when duplication occurs.
-			Item item = recipe.getProduct();
-			String name = itemNameFixer.apply(item);
+			ItemStack item = recipe.getProduct();
+			String name = itemNameFixer.apply(item.getItem());
 			String resolved;
 			if ((resolved = resolvedRecipes.get(recipe)) != null) return resolved;
-			if (item instanceof DyeItem) {
+			if (item.getItem() instanceof DyeItem) {
 				Map<String, Integer> costs = recipe.getCosts();
 				if (costs.size() == 2 && costs.containsKey("WHITE DYE") &&
 					costs.keySet().stream().filter(c -> c.endsWith("DYE")).count() == 1)
@@ -305,7 +306,7 @@ public class Recipes {
 						return name + "_from_" + cost.toLowerCase().replace(' ', '_');
 					}
 				}
-			} else if (item instanceof FurnitureItem && ((FurnitureItem) item).furniture instanceof Bed) {
+			} else if (item.getItem() instanceof FurnitureItem && item.get(ComponentTypes.FURNITURE).furniture() instanceof Bed) {
 				if (recipe.getCosts().containsKey("WHITE BED"))
 					return name + "_from_white_bed";
 				return name;
@@ -326,7 +327,7 @@ public class Recipes {
 					recipeMap.put(recipeNameFixer.apply(recipe), recipe);
 				}
 			} else {
-				recipeMap.put(itemNameFixer.apply(recipe.getProduct()), recipe);
+				recipeMap.put(itemNameFixer.apply(recipe.getProduct().getItem()), recipe);
 			}
 		}
 		for (String key : duplicatedRecipes.keySet()) {
@@ -425,7 +426,7 @@ public class Recipes {
 			JSONObject criteriaJson = new JSONObject();
 			Map<String, Integer> costMap = recipe.getCosts();
 			for (String itemKey : costMap.keySet()) {
-				Item item = Items.get(itemKey);
+				ItemStack item = Items.getStackOf(itemKey);
 				JSONObject criterionJson = new JSONObject();
 
 				criterionJson.put("trigger", "inventory_changed");
@@ -439,7 +440,7 @@ public class Recipes {
 				itemConditionsJsonArray.put(itemConditionsJson);
 				conditionsJson.put("items", itemConditionsJsonArray);
 				criterionJson.put("conditions", conditionsJson);
-				criteriaJson.put("has_" + itemNameFixer.apply(item), criterionJson);
+				criteriaJson.put("has_" + itemNameFixer.apply(item.getItem()), criterionJson);
 
 				costs.add(item.getName() + "_" + costMap.get(itemKey));
 			}
@@ -455,7 +456,7 @@ public class Recipes {
 			JSONObject recipesJson = new JSONObject();
 			JSONArray costsJson = new JSONArray();
 			costsJson.putAll(costs);
-			recipesJson.put(recipe.getProduct().getName() + "_" + recipe.getAmount(), costsJson);
+			recipesJson.put(recipe.getProduct().getItem().getName() + "_" + recipe.getAmount(), costsJson);
 			rewardsJson.put("recipes", recipesJson);
 			recipeUnlockingJson.put("rewards", rewardsJson);
 

--- a/src/client/java/minicraft/item/StackableItem.java
+++ b/src/client/java/minicraft/item/StackableItem.java
@@ -5,7 +5,6 @@ import minicraft.core.io.Localization;
 import minicraft.gfx.SpriteLinker;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -44,17 +43,11 @@ public class StackableItem extends Item {
 		return items;
 	}
 
-	public int count;
-	public int maxCount = 100;
+// 	public int count;
 
 	protected StackableItem(String name, LinkedSprite sprite) {
 		super(name, sprite);
-		count = 1;
-	}
-
-	protected StackableItem(String name, LinkedSprite sprite, int count) {
-		this(name, sprite);
-		this.count = count;
+		this.maxCount = 100;
 	}
 
 	public boolean stacksWith(Item other) {
@@ -62,9 +55,9 @@ public class StackableItem extends Item {
 	}
 
 	// This is used by (most) subclasses, to standardize the count decrement behavior. This is not the normal interactOn method.
-	protected boolean interactOn(boolean subClassSuccess) {
+	protected boolean interactOn(boolean subClassSuccess, ItemStack stack) {
 		if (subClassSuccess && !Game.isMode("minicraft.settings.mode.creative"))
-			count--;
+			stack.decrement(1);
 		return subClassSuccess;
 	}
 
@@ -72,27 +65,17 @@ public class StackableItem extends Item {
 	 * Called to determine if this item should be removed from an inventory.
 	 */
 	@Override
-	public boolean isDepleted() {
-		return count <= 0;
+	public boolean isDepleted(ItemStack stack) {
+		return stack.getCount() <= 0;
+	}
+
+	public String getData(ItemStack stack) {
+		return getName() + "_" + stack.getCount();
 	}
 
 	@Override
-	public @NotNull StackableItem copy() {
-		return new StackableItem(getName(), sprite, count);
-	}
-
-	@Override
-	public String toString() {
-		return super.toString() + "-Stack_Size:" + count;
-	}
-
-	public String getData() {
-		return getName() + "_" + count;
-	}
-
-	@Override
-	public String getDisplayName() {
-		String amt = (Math.min(count, 999)) + " ";
+	public String getDisplayName(ItemStack stack) {
+		String amt = (Math.min(stack.getCount(), 999)) + " ";
 		return " " + amt + Localization.getLocalized(getName());
 	}
 }

--- a/src/client/java/minicraft/item/SummonItem.java
+++ b/src/client/java/minicraft/item/SummonItem.java
@@ -12,7 +12,6 @@ import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
-import org.jetbrains.annotations.NotNull;
 import org.tinylog.Logger;
 
 import java.awt.Rectangle;
@@ -32,18 +31,14 @@ public class SummonItem extends StackableItem {
 	private final String mob;
 
 	private SummonItem(String name, LinkedSprite sprite, String mob) {
-		this(name, sprite, 1, mob);
-	}
-
-	private SummonItem(String name, LinkedSprite sprite, int count, String mob) {
-		super(name, sprite, count);
+		super(name, sprite);
 		this.mob = mob;
 	}
 
 	/**
 	 * What happens when the player uses the item on a tile
 	 */
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		boolean success = false;
 
 		switch (mob) {
@@ -106,15 +101,11 @@ public class SummonItem extends StackableItem {
 				break;
 		}
 
-		return super.interactOn(success);
+		return super.interactOn(success, stack);
 	}
 
 	@Override
-	public boolean interactsWithWorld() {
+	public boolean interactsWithWorld(ItemStack stack) {
 		return false;
-	}
-
-	public @NotNull SummonItem copy() {
-		return new SummonItem(getName(), sprite, count, mob);
 	}
 }

--- a/src/client/java/minicraft/item/TileItem.java
+++ b/src/client/java/minicraft/item/TileItem.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.IntFunction;
 
 public class TileItem extends StackableItem {
 
@@ -114,15 +113,11 @@ public class TileItem extends StackableItem {
 	public final List<String> validTiles;
 
 	protected TileItem(String name, LinkedSprite sprite, TileModel model, String... validTiles) {
-		this(name, sprite, 1, model, Arrays.asList(validTiles));
+		this(name, sprite, model, Arrays.asList(validTiles));
 	}
 
-	protected TileItem(String name, LinkedSprite sprite, int count, TileModel model, String... validTiles) {
-		this(name, sprite, count, model, Arrays.asList(validTiles));
-	}
-
-	protected TileItem(String name, LinkedSprite sprite, int count, @Nullable TileModel model, List<String> validTiles) {
-		super(name, sprite, count);
+	protected TileItem(String name, LinkedSprite sprite, @Nullable TileModel model, List<String> validTiles) {
+		super(name, sprite);
 		this.model = model;
 		this.validTiles = new ArrayList<>();
 		for (String tile : validTiles)
@@ -160,18 +155,18 @@ public class TileItem extends StackableItem {
 		}
 	}
 
-	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
+	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir, ItemStack stack) {
 		for (String tilename : validTiles) {
 			if (tile.matches(level.getData(xt, yt), tilename)) {
 				Tile t = TileModel.getTile(model);
 				level.setTile(xt, yt, t, TileModel.getTileData(model, t, tile, level, xt, yt, player, attackDir));
 				AdvancementElement.AdvancementTrigger.PlacedTileTrigger.INSTANCE.trigger(
 					new AdvancementElement.AdvancementTrigger.PlacedTileTrigger.PlacedTileTriggerConditionHandler.PlacedTileTriggerConditions(
-						this, level.getTile(xt, yt), level.getData(xt, yt), xt, yt, level.depth
+						new ItemStack(this), level.getTile(xt, yt), level.getData(xt, yt), xt, yt, level.depth
 					));
 
 				Sound.play("craft");
-				return super.interactOn(true);
+				return super.interactOn(true, stack);
 			}
 		}
 
@@ -192,7 +187,7 @@ public class TileItem extends StackableItem {
 			}
 		}
 
-		return super.interactOn(false);
+		return super.interactOn(false, stack);
 	}
 
 	@Override
@@ -203,9 +198,5 @@ public class TileItem extends StackableItem {
 	@Override
 	public int hashCode() {
 		return super.hashCode() + (model == null ? 0xFF123 : model.hashCode());
-	}
-
-	public @NotNull TileItem copy() {
-		return new TileItem(getName(), sprite, count, model, validTiles);
 	}
 }

--- a/src/client/java/minicraft/item/UnknownItem.java
+++ b/src/client/java/minicraft/item/UnknownItem.java
@@ -2,15 +2,9 @@ package minicraft.item;
 
 import minicraft.gfx.SpriteLinker;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import org.jetbrains.annotations.NotNull;
 
 public class UnknownItem extends StackableItem {
-
 	protected UnknownItem(String reqName) {
 		super(reqName, SpriteLinker.missingTexture(SpriteType.Item));
-	}
-
-	public @NotNull UnknownItem copy() {
-		return new UnknownItem(getName());
 	}
 }

--- a/src/client/java/minicraft/item/WoolItem.java
+++ b/src/client/java/minicraft/item/WoolItem.java
@@ -2,7 +2,6 @@ package minicraft.item;
 
 import minicraft.gfx.SpriteLinker;
 import minicraft.util.MyUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
@@ -23,10 +22,5 @@ public class WoolItem extends TileItem {
 	protected WoolItem(String name, SpriteLinker.LinkedSprite sprite, DyeItem.DyeColor color) {
 		super(name, sprite, new TileModel(name), "hole", "water");
 		this.color = color;
-	}
-
-	@Override
-	public @NotNull TileItem copy() {
-		return new WoolItem(getName(), sprite, color);
 	}
 }

--- a/src/client/java/minicraft/item/component/ComponentMap.java
+++ b/src/client/java/minicraft/item/component/ComponentMap.java
@@ -1,0 +1,95 @@
+package minicraft.item.component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ComponentMap {
+	private final ComponentMap baseMap;
+	private final Map<ComponentType<?>, Object> map;
+
+	public ComponentMap() {
+		this(null, new HashMap<>());
+	}
+
+	public ComponentMap(ComponentMap baseMap) {
+		this(baseMap, new HashMap<>());
+	}
+
+	public ComponentMap(Map<ComponentType<?>, Object> components) {
+		this(null, components);
+	}
+
+	public ComponentMap(ComponentMap baseMap, Map<ComponentType<?>, Object> components) {
+		this.baseMap = baseMap;
+		this.map = components;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public <T> void put(ComponentType<T> type, T value) {
+		this.map.put(type, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T get(ComponentType<T> type) {
+		if (this.map.containsKey(type)) {
+			return (T) this.map.get(type);
+		}
+		return this.baseMap == null ? null : this.baseMap.get(type);
+	}
+
+	public <T> T getOrDefault(ComponentType<T> type, T fallback) {
+		T value = this.get(type);
+		return value != null ? value : fallback;
+	}
+
+	public boolean has(ComponentType<?> type) {
+		return this.map.containsKey(type) || (this.baseMap != null && this.baseMap.has(type));
+	}
+
+	public int size() {
+		return this.map.size();
+	}
+
+	public ComponentMap copy() {
+		return new ComponentMap(this.baseMap, new HashMap<>(this.map));
+	}
+
+	public ImmutableComponentMap asImmutable() {
+		return new ImmutableComponentMap(this);
+	}
+
+	public static class ImmutableComponentMap extends ComponentMap {
+		public ImmutableComponentMap(ComponentMap baseMap) {
+			super(baseMap);
+		}
+
+		public ImmutableComponentMap(Map<ComponentType<?>, Object> map) {
+			super(map);
+		}
+
+		@Override
+		public <T> void put(ComponentType<T> type, T value) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	public static class Builder {
+		private final Map<ComponentType<?>, Object> map;
+
+		private Builder() {
+			this.map = new HashMap<>();
+		}
+
+		public <T> Builder add(ComponentType<T> type, T value) {
+			this.map.put(type, value);
+			return this;
+		}
+
+		public ComponentMap build() {
+			return new ImmutableComponentMap(this.map);
+		}
+	}
+}

--- a/src/client/java/minicraft/item/component/ComponentType.java
+++ b/src/client/java/minicraft/item/component/ComponentType.java
@@ -1,0 +1,13 @@
+package minicraft.item.component;
+
+public class ComponentType<T> {
+	private final String name;
+
+	public ComponentType(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+}

--- a/src/client/java/minicraft/item/component/ComponentTypes.java
+++ b/src/client/java/minicraft/item/component/ComponentTypes.java
@@ -1,0 +1,16 @@
+package minicraft.item.component;
+
+import minicraft.item.component.type.BookContentComponent;
+import minicraft.item.component.type.FurnitureComponent;
+import minicraft.item.component.type.WateringCanComponent;
+
+public final class ComponentTypes {
+	public static final ComponentType<Integer> DURABILITY = new ComponentType<>("dur");
+	public static final ComponentType<Integer> FISHING_ROD_USES = new ComponentType<>("uses");
+	public static final ComponentType<BookContentComponent> BOOK_CONTENT = new ComponentType<>("book_content");
+	public static final ComponentType<FurnitureComponent> FURNITURE = new ComponentType<>("furniture");
+	public static final ComponentType<WateringCanComponent> WATERING_CAN = new ComponentType<>("wateringcan");
+
+	private ComponentTypes() {
+	}
+}

--- a/src/client/java/minicraft/item/component/type/BookContentComponent.java
+++ b/src/client/java/minicraft/item/component/type/BookContentComponent.java
@@ -1,0 +1,21 @@
+package minicraft.item.component.type;
+
+import minicraft.item.BookItem;
+
+public class BookContentComponent {
+	private final BookItem.BookContent content;
+	private final boolean hasTitlePage;
+
+	public BookContentComponent(BookItem.BookContent content, boolean hasTitlePage) {
+		this.content = content;
+		this.hasTitlePage = hasTitlePage;
+	}
+
+	public BookItem.BookContent content() {
+		return this.content;
+	}
+
+	public boolean hasTitlePage() {
+		return this.hasTitlePage;
+	}
+}

--- a/src/client/java/minicraft/item/component/type/FurnitureComponent.java
+++ b/src/client/java/minicraft/item/component/type/FurnitureComponent.java
@@ -1,0 +1,33 @@
+package minicraft.item.component.type;
+
+import minicraft.entity.furniture.Furniture;
+
+public class FurnitureComponent {
+	private final Furniture furniture;
+	private final boolean placed;  // Value if the furniture has been placed or not.
+
+	public FurnitureComponent(Furniture furniture) {
+		this(furniture, false);
+	}
+
+	public FurnitureComponent(Furniture furniture, boolean placed) {
+		this.furniture = furniture;
+		this.placed = placed;
+	}
+
+	public FurnitureComponent with(Furniture furniture) {
+		return new FurnitureComponent(furniture, this.placed);
+	}
+
+	public FurnitureComponent withPlaced(boolean placed) {
+		return new FurnitureComponent(this.furniture, placed);
+	}
+
+	public Furniture furniture() {
+		return this.furniture;
+	}
+
+	public boolean placed() {
+		return this.placed;
+	}
+}

--- a/src/client/java/minicraft/item/component/type/WateringCanComponent.java
+++ b/src/client/java/minicraft/item/component/type/WateringCanComponent.java
@@ -1,0 +1,27 @@
+package minicraft.item.component.type;
+
+public class WateringCanComponent {
+	private final int content;
+	private final int renderingTick;
+
+	public WateringCanComponent(int content, int renderingTick) {
+		this.content = content;
+		this.renderingTick = renderingTick;
+	}
+
+	public WateringCanComponent withContent(int content) {
+		return new WateringCanComponent(content, this.renderingTick);
+	}
+
+	public WateringCanComponent withRenderingTick(int renderingTick) {
+		return new WateringCanComponent(this.content, renderingTick);
+	}
+
+	public int content() {
+		return this.content;
+	}
+
+	public int renderingTick() {
+		return this.renderingTick;
+	}
+}

--- a/src/client/java/minicraft/level/Level.java
+++ b/src/client/java/minicraft/level/Level.java
@@ -30,6 +30,7 @@ import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
 import minicraft.item.DyeItem;
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.level.tile.Tile;
 import minicraft.level.tile.Tiles;
 import minicraft.level.tile.TorchTile;
@@ -555,21 +556,21 @@ public class Level {
 		}
 	}
 
-	public void dropItem(int x, int y, int mincount, int maxcount, Item... items) {
+	public void dropItem(int x, int y, int mincount, int maxcount, ItemStack... items) {
 		dropItem(x, y, mincount + random.nextInt(maxcount - mincount + 1), items);
 	}
 
-	public void dropItem(int x, int y, int count, Item... items) {
+	public void dropItem(int x, int y, int count, ItemStack... items) {
 		for (int i = 0; i < count; i++)
 			dropItem(x, y, items);
 	}
 
-	public void dropItem(int x, int y, Item... items) {
-		for (Item i : items)
+	public void dropItem(int x, int y, ItemStack... items) {
+		for (ItemStack i : items)
 			dropItem(x, y, i);
 	}
 
-	public ItemEntity dropItem(int x, int y, Item i) {
+	public ItemEntity dropItem(int x, int y, ItemStack i) {
 		int ranx, rany;
 
 		do {

--- a/src/client/java/minicraft/level/tile/BossDoorTile.java
+++ b/src/client/java/minicraft/level/tile/BossDoorTile.java
@@ -7,7 +7,7 @@ import minicraft.entity.Direction;
 import minicraft.entity.mob.Mob;
 import minicraft.entity.mob.ObsidianKnight;
 import minicraft.entity.mob.Player;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
 
@@ -18,11 +18,10 @@ public class BossDoorTile extends DoorTile {
 		super(Material.Obsidian, "Boss Door");
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
-			if (item instanceof ToolItem) {
-				ToolItem tool = (ToolItem) item;
-				if (tool.type == type.getRequiredTool()) {
+			if (item != null && item.getItem() instanceof ToolItem) {
+				if (item.<ToolItem>getItemAs().type == type.getRequiredTool()) {
 					if (player.payStamina(1)) {
 						Game.notifications.add(Localization.getLocalized(doorMsg));
 						Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/BossFloorTile.java
+++ b/src/client/java/minicraft/level/tile/BossFloorTile.java
@@ -6,7 +6,7 @@ import minicraft.core.io.Sound;
 import minicraft.entity.Direction;
 import minicraft.entity.mob.ObsidianKnight;
 import minicraft.entity.mob.Player;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
 
@@ -17,10 +17,10 @@ public class BossFloorTile extends FloorTile {
 		super(Material.Obsidian, "Boss Floor");
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
-			if (item instanceof ToolItem) {
-				ToolItem tool = (ToolItem) item;
+			if (item.getItem() instanceof ToolItem) {
+				ToolItem tool = (ToolItem) item.getItem();
 				if (tool.type == type.getRequiredTool()) {
 					if (player.payStamina(1)) {
 						Game.notifications.add(Localization.getLocalized(floorMsg));

--- a/src/client/java/minicraft/level/tile/BossWallTile.java
+++ b/src/client/java/minicraft/level/tile/BossWallTile.java
@@ -8,7 +8,7 @@ import minicraft.entity.mob.ObsidianKnight;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
 
@@ -23,11 +23,10 @@ public class BossWallTile extends WallTile {
 		sprite = obsidian; // Renewing the connectivity.
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if ((!ObsidianKnight.beaten || ObsidianKnight.active) && !Game.isMode("minicraft.settings.mode.creative")) {
-			if (item instanceof ToolItem) {
-				ToolItem tool = (ToolItem) item;
-				if (tool.type == type.getRequiredTool()) {
+			if (item.getItem() instanceof ToolItem) {
+				if (item.<ToolItem>getItemAs().type == type.getRequiredTool()) {
 					if (player.payStamina(1)) {
 						Game.notifications.add(Localization.getLocalized(wallMsg));
 						Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/CactusTile.java
+++ b/src/client/java/minicraft/level/tile/CactusTile.java
@@ -43,7 +43,7 @@ public class CactusTile extends Tile {
 			//int count = random.nextInt(2) + 2;
 			level.setTile(x, y, Tiles.get("sand"));
 			Sound.play("monsterhurt");
-			level.dropItem((x << 4) + 8, (y << 4) + 8, 2, 4, Items.get("Cactus"));
+			level.dropItem((x << 4) + 8, (y << 4) + 8, 2, 4, Items.getStackOf("Cactus"));
 		} else {
 			level.setData(x, y, damage);
 		}

--- a/src/client/java/minicraft/level/tile/CloudTile.java
+++ b/src/client/java/minicraft/level/tile/CloudTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.Entity;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -26,15 +26,15 @@ public class CloudTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		// We don't want the tile to break when attacked with just anything, even in creative mode
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel && player.payStamina(5)) {
 				int data = level.getData(xt, yt);
 				level.setTile(xt, yt, Tiles.get("Infinite Fall")); // Would allow you to shovel cloud, I think.
 				Sound.play("monsterhurt");
-				level.dropItem((xt << 4) + 8, (yt << 4) + 8, 1, 3, Items.get("Cloud"));
+				level.dropItem((xt << 4) + 8, (yt << 4) + 8, 1, 3, Items.getStackOf("Cloud"));
 				AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 					new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 						item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/DecorTile.java
+++ b/src/client/java/minicraft/level/tile/DecorTile.java
@@ -7,7 +7,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -55,27 +55,27 @@ public class DecorTile extends Tile {
 		screen.render(x * 16 + 0, y * 16, sprite.getCurrentFrame().getSprite().spritePixels[0][0]);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == mType.getRequiredTool()) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					if (level.depth == 1) {
 						level.setTile(xt, yt, Tiles.get("Cloud"));
 					} else {
 						level.setTile(xt, yt, Tiles.get("Hole"));
 					}
-					Item drop;
+					ItemStack drop;
 					switch (thisType) {
 						case ORNATE_STONE:
-							drop = Items.get("Ornate Stone");
+							drop = Items.getStackOf("Ornate Stone");
 							break;
 						case ORNATE_OBSIDIAN:
-							drop = Items.get("Ornate Obsidian");
+							drop = Items.getStackOf("Ornate Obsidian");
 							break;
 						case ORNATE_WOOD:
-							drop = Items.get("Ornate Wood");
+							drop = Items.getStackOf("Ornate Wood");
 							break;
 						default:
 							throw new IllegalStateException("Unexpected value: " + thisType);

--- a/src/client/java/minicraft/level/tile/DirtTile.java
+++ b/src/client/java/minicraft/level/tile/DirtTile.java
@@ -7,7 +7,7 @@ import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -54,15 +54,15 @@ public class DirtTile extends Tile {
 		levelSprite[dIdx(level.depth)].render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Hole"));
 					Sound.play("monsterhurt");
-					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get("Dirt"));
+					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf("Dirt"));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, xt, yt, level.depth));
@@ -70,7 +70,7 @@ public class DirtTile extends Tile {
 				}
 			}
 			if (tool.type == ToolType.Hoe) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Farmland"));
 					Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/DoorTile.java
+++ b/src/client/java/minicraft/level/tile/DoorTile.java
@@ -8,7 +8,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -49,15 +49,15 @@ public class DoorTile extends Tile {
 		curSprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == type.getRequiredTool()) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get((short) (id + 3))); // Will get the corresponding floor tile.
 					Sound.play("monsterhurt");
-					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get(type.name() + " Door"));
+					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf(type.name() + " Door"));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/FenceTile.java
+++ b/src/client/java/minicraft/level/tile/FenceTile.java
@@ -10,7 +10,7 @@ import minicraft.entity.particle.SmashParticle;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -107,16 +107,16 @@ public class FenceTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == type.getRequiredTool()) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					Sound.play("monsterhurt");
-					level.dropItem(xt * 16 + 8, yt * 16 + 8, Items.get(name));
+					level.dropItem(xt * 16 + 8, yt * 16 + 8, Items.getStackOf(name));
 					level.setTile(xt, yt, Tiles.get((short) level.getData(xt, yt)));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
@@ -132,7 +132,7 @@ public class FenceTile extends Tile {
 		if (Game.isMode("minicraft.settings.mode.creative")) {
 			level.add(new SmashParticle(x * 16, y * 16));
 			Sound.play("monsterhurt");
-			level.dropItem(x * 16 + 8, y * 16 + 8, Items.get(name));
+			level.dropItem(x * 16 + 8, y * 16 + 8, Items.getStackOf(name));
 			level.setTile(x, y, Tiles.get((short) level.getData(x, y)));
 		}
 	}

--- a/src/client/java/minicraft/level/tile/FloorTile.java
+++ b/src/client/java/minicraft/level/tile/FloorTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.Entity;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -36,24 +36,24 @@ public class FloorTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == type.getRequiredTool()) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					if (level.depth == 1) {
 						level.setTile(xt, yt, Tiles.get("Cloud"));
 					} else {
 						level.setTile(xt, yt, Tiles.get("Hole"));
 					}
-					Item drop;
+					ItemStack drop;
 					switch (type) {
 						case Wood:
-							drop = Items.get("Plank");
+							drop = Items.getStackOf("Plank");
 							break;
 						default:
-							drop = Items.get(type.name() + " Brick");
+							drop = Items.getStackOf(type.name() + " Brick");
 							break;
 					}
 					Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/FlowerTile.java
+++ b/src/client/java/minicraft/level/tile/FlowerTile.java
@@ -7,7 +7,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -80,15 +80,15 @@ public class FlowerTile extends Tile {
 		FlowerVariant.values()[level.getData(x, y)].sprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int x, int y, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int x, int y, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(2 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(2 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(x, y);
 					level.setTile(x, y, Tiles.get("Grass"));
 					Sound.play("monsterhurt");
-					level.dropItem((x << 4) + 8, (y << 4) + 8, Items.get(FlowerVariant.values()[level.getData(x, y)].name));
+					level.dropItem((x << 4) + 8, (y << 4) + 8, Items.getStackOf(FlowerVariant.values()[level.getData(x, y)].name));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, x, y, level.depth));
@@ -100,7 +100,7 @@ public class FlowerTile extends Tile {
 	}
 
 	public boolean hurt(Level level, int x, int y, Mob source, int dmg, Direction attackDir) {
-		level.dropItem((x << 4) + 8, (y << 4) + 8, Items.get(FlowerVariant.values()[level.getData(x, y)].name));
+		level.dropItem((x << 4) + 8, (y << 4) + 8, Items.getStackOf(FlowerVariant.values()[level.getData(x, y)].name));
 		level.setTile(x, y, Tiles.get("Grass"));
 		return true;
 	}

--- a/src/client/java/minicraft/level/tile/GrassTile.java
+++ b/src/client/java/minicraft/level/tile/GrassTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -50,16 +50,16 @@ public class GrassTile extends Tile {
 		sprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Dirt"));
 					Sound.play("monsterhurt");
 					if (random.nextInt(5) == 0) { // 20% chance to drop Grass seeds
-						level.dropItem((xt << 4) + 8, (yt << 4) + 8, 1, Items.get("Grass Seeds"));
+						level.dropItem((xt << 4) + 8, (yt << 4) + 8, 1, Items.getStackOf("Grass Seeds"));
 					}
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
@@ -68,12 +68,12 @@ public class GrassTile extends Tile {
 				}
 			}
 			if (tool.type == ToolType.Hoe) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Farmland"));
 					Sound.play("monsterhurt");
 					if (random.nextInt(5) != 0) { // 80% chance to drop Wheat seeds
-						level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get("Wheat Seeds"));
+						level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf("Wheat Seeds"));
 					}
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
@@ -82,7 +82,7 @@ public class GrassTile extends Tile {
 				}
 			}
 			if (tool.type == ToolType.Pickaxe) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					level.setTile(xt, yt, Tiles.get("Path"));
 					Sound.play("monsterhurt");
 				}

--- a/src/client/java/minicraft/level/tile/HardRockTile.java
+++ b/src/client/java/minicraft/level/tile/HardRockTile.java
@@ -12,7 +12,7 @@ import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -38,15 +38,15 @@ public class HardRockTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 
 			// If we are hitting with a gem pickaxe.
 			if (tool.type == ToolType.Pickaxe && tool.level == 4) {
-				if (player.payStamina(2) && tool.payDurability()) {
+				if (player.payStamina(2) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					hurt(level, xt, yt, tool.getDamage());
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
@@ -71,8 +71,8 @@ public class HardRockTile extends Tile {
 		level.add(new TextParticle("" + dmg, (x << 4) + 8, (y << 4) + 8, Color.RED));
 		if (damage >= hrHealth) {
 			level.setTile(x, y, Tiles.get("dirt"));
-			level.dropItem((x << 4) + 8, (y << 4) + 8, 1, 3, Items.get("Stone"));
-			level.dropItem((x << 4) + 8, (y << 4) + 8, 0, 1, Items.get("Coal"));
+			level.dropItem((x << 4) + 8, (y << 4) + 8, 1, 3, Items.getStackOf("Stone"));
+			level.dropItem((x << 4) + 8, (y << 4) + 8, 0, 1, Items.getStackOf("Coal"));
 		} else {
 			level.setData(x, y, damage);
 		}

--- a/src/client/java/minicraft/level/tile/LavaBrickTile.java
+++ b/src/client/java/minicraft/level/tile/LavaBrickTile.java
@@ -7,7 +7,7 @@ import minicraft.entity.mob.Mob;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
 import minicraft.level.Level;
@@ -18,11 +18,11 @@ public class LavaBrickTile extends Tile {
 		super(name, new SpriteAnimation(SpriteType.Tile, "missing_tile"));
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Pickaxe) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Lava"));
 					Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/MaterialTile.java
+++ b/src/client/java/minicraft/level/tile/MaterialTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.Entity;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -30,24 +30,24 @@ public class MaterialTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == type.getRequiredTool()) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					if (level.depth == 1) {
 						level.setTile(xt, yt, Tiles.get("Cloud"));
 					} else {
 						level.setTile(xt, yt, Tiles.get("Hole"));
 					}
-					Item drop;
+					ItemStack drop;
 					switch (type) {
 						case Stone:
-							drop = Items.get("Stone");
+							drop = Items.getStackOf("Stone");
 							break;
 						case Obsidian:
-							drop = Items.get("Raw Obsidian");
+							drop = Items.getStackOf("Raw Obsidian");
 							break;
 						default:
 							throw new IllegalStateException("Unexpected value: " + type);

--- a/src/client/java/minicraft/level/tile/OreTile.java
+++ b/src/client/java/minicraft/level/tile/OreTile.java
@@ -12,7 +12,7 @@ import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -25,21 +25,21 @@ public class OreTile extends Tile {
 	private final OreType type;
 
 	public enum OreType {
-		Iron(Items.get("Iron Ore"), new SpriteAnimation(SpriteType.Tile, "iron_ore")),
-		Lapis(Items.get("Lapis"), new SpriteAnimation(SpriteType.Tile, "lapis_ore")),
-		Gold(Items.get("Gold Ore"), new SpriteAnimation(SpriteType.Tile, "gold_ore")),
-		Gem(Items.get("Gem"), new SpriteAnimation(SpriteType.Tile, "gem_ore")),
-		Cloud(Items.get("Cloud Ore"), new SpriteAnimation(SpriteType.Tile, "cloud_ore"));
+		Iron(Items.getStackOf("Iron Ore"), new SpriteAnimation(SpriteType.Tile, "iron_ore")),
+		Lapis(Items.getStackOf("Lapis"), new SpriteAnimation(SpriteType.Tile, "lapis_ore")),
+		Gold(Items.getStackOf("Gold Ore"), new SpriteAnimation(SpriteType.Tile, "gold_ore")),
+		Gem(Items.getStackOf("Gem"), new SpriteAnimation(SpriteType.Tile, "gem_ore")),
+		Cloud(Items.getStackOf("Cloud Ore"), new SpriteAnimation(SpriteType.Tile, "cloud_ore"));
 
-		private final Item drop;
+		private final ItemStack drop;
 		public final SpriteAnimation sheet;
 
-		OreType(Item drop, SpriteAnimation sheet) {
+		OreType(ItemStack drop, SpriteAnimation sheet) {
 			this.drop = drop;
 			this.sheet = sheet;
 		}
 
-		private Item getOre() {
+		private ItemStack getOre() {
 			return drop.copy();
 		}
 	}
@@ -66,13 +66,13 @@ public class OreTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Pickaxe) {
-				if (player.payStamina(6 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(6 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					hurt(level, xt, yt, tool.getDamage());
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
@@ -85,7 +85,7 @@ public class OreTile extends Tile {
 		return false;
 	}
 
-	public Item getOre() {
+	public ItemStack getOre() {
 		return type.getOre();
 	}
 
@@ -110,7 +110,7 @@ public class OreTile extends Tile {
 			} else {
 				level.setData(x, y, damage);
 			}
-			if (type.drop.equals(Items.get("gem"))) {
+			if (type.drop.equals(Items.getStackOf("gem"))) {
 				AchievementsDisplay.setAchievement("minicraft.achievement.find_gem", true);
 			}
 			level.dropItem((x << 4) + 8, (y << 4) + 8, count, type.getOre());

--- a/src/client/java/minicraft/level/tile/PathTile.java
+++ b/src/client/java/minicraft/level/tile/PathTile.java
@@ -5,7 +5,7 @@ import minicraft.entity.Direction;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -25,15 +25,15 @@ public class PathTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Hole"));
 					Sound.play("monsterhurt");
-					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get("Dirt"));
+					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf("Dirt"));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/RockTile.java
+++ b/src/client/java/minicraft/level/tile/RockTile.java
@@ -13,7 +13,7 @@ import minicraft.gfx.Color;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -51,10 +51,10 @@ public class RockTile extends Tile {
 		return true;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
-			if (tool.type == ToolType.Pickaxe && player.payStamina(5 - tool.level) && tool.payDurability()) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
+			if (tool.type == ToolType.Pickaxe && player.payStamina(5 - tool.level) && tool.payDurability(item)) {
 				int data = level.getData(xt, yt);
 				// Drop coal since we use a pickaxe.
 				dropCoal = true;
@@ -90,10 +90,10 @@ public class RockTile extends Tile {
 					coal += 1;
 				}
 
-				level.dropItem((x << 4) + 8, (y << 4) + 8, 0, coal, Items.get("Coal"));
+				level.dropItem((x << 4) + 8, (y << 4) + 8, 0, coal, Items.getStackOf("Coal"));
 			}
 
-			level.dropItem((x << 4) + 8, (y << 4) + 8, stone, Items.get("Stone"));
+			level.dropItem((x << 4) + 8, (y << 4) + 8, stone, Items.getStackOf("Stone"));
 			level.setTile(x, y, Tiles.get("Dirt"));
 		} else {
 			level.setData(x, y, damage);

--- a/src/client/java/minicraft/level/tile/SandTile.java
+++ b/src/client/java/minicraft/level/tile/SandTile.java
@@ -9,7 +9,7 @@ import minicraft.entity.particle.SandParticle;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -61,15 +61,15 @@ public class SandTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Hole"));
 					Sound.play("monsterhurt");
-					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get("Sand"));
+					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf("Sand"));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/SignTile.java
+++ b/src/client/java/minicraft/level/tile/SignTile.java
@@ -1,25 +1,21 @@
 package minicraft.level.tile;
 
 import minicraft.core.Game;
-import minicraft.core.Renderer;
 import minicraft.core.io.Sound;
 import minicraft.entity.Direction;
-import minicraft.entity.Entity;
 import minicraft.entity.mob.Mob;
 import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
 import minicraft.level.Level;
 import minicraft.level.tile.entity.SignTileEntity;
 import minicraft.screen.SignDisplay;
-import minicraft.screen.SignDisplayMenu;
 import minicraft.util.AdvancementElement;
-import org.tinylog.Logger;
 
 public class SignTile extends Tile {
 	protected SignTile() {
@@ -46,14 +42,14 @@ public class SignTile extends Tile {
 		sprite.render(screen, level, x, y);
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (item != null) {
-			if (item instanceof ToolItem && ((ToolItem) item).type == ToolType.Axe) {
+			if (item.getItem() instanceof ToolItem && ((ToolItem) item.getItem()).type == ToolType.Axe) {
 				int data = level.getData(xt, yt);
 				level.setTile(xt, yt, Tiles.get((short) data));
 				SignDisplay.removeSign(level.depth, xt, yt);
 				Sound.play("monsterhurt");
-				level.dropItem(xt*16+8, yt*16+8, Items.get("Sign"));
+				level.dropItem(xt*16+8, yt*16+8, Items.getStackOf("Sign"));
 				AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 					new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 						item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/StairsTile.java
+++ b/src/client/java/minicraft/level/tile/StairsTile.java
@@ -9,7 +9,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PowerGloveItem;
 import minicraft.level.Level;
 import minicraft.util.AdvancementElement;
@@ -37,11 +37,11 @@ public class StairsTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		super.interact(level, xt, yt, player, item, attackDir);
 
 		// Makes it so you can remove the stairs if you are in creative and debug mode.
-		if (item instanceof PowerGloveItem && Game.isMode("minicraft.settings.mode.creative")) {
+		if (item.getItem() instanceof PowerGloveItem && Game.isMode("minicraft.settings.mode.creative")) {
 			int data = level.getData(xt, yt);
 			level.setTile(xt, yt, Tiles.get("Grass"));
 			Sound.play("monsterhurt");

--- a/src/client/java/minicraft/level/tile/Tile.java
+++ b/src/client/java/minicraft/level/tile/Tile.java
@@ -9,6 +9,7 @@ import minicraft.entity.vehicle.Boat;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolType;
 import minicraft.level.Level;
 
@@ -146,7 +147,7 @@ public abstract class Tile {
 	 * @param attackDir The direction of the player attacking.
 	 * @return Was the operation successful?
 	 */
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		return false;
 	}
 
@@ -186,7 +187,7 @@ public abstract class Tile {
 
 	/**
 	 * @deprecated Similar to {@link #getData(String)}. Also, param {@code thisData} is unused.
-	 * 	The current only usage is in {@link minicraft.item.TileItem#interactOn(Tile, Level, int, int, Player, Direction)}.
+	 * 	The current only usage is in {@link Item#interactOn(Tile, Level, int, int, Player, Direction, ItemStack)}.
 	 */
 	@Deprecated
 	public boolean matches(int thisData, String tileInfo) {

--- a/src/client/java/minicraft/level/tile/TorchTile.java
+++ b/src/client/java/minicraft/level/tile/TorchTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.PowerGloveItem;
 import minicraft.level.Level;
@@ -41,12 +41,12 @@ public class TorchTile extends Tile {
 		return 5;
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof PowerGloveItem) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof PowerGloveItem) {
 			int data = level.getData(xt, yt);
 			level.setTile(xt, yt, Tiles.get((short) data));
 			Sound.play("monsterhurt");
-			level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get("Torch"));
+			level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf("Torch"));
 			AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 				new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 					item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/TreeTile.java
+++ b/src/client/java/minicraft/level/tile/TreeTile.java
@@ -13,7 +13,7 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.Sprite;
 import minicraft.gfx.SpriteLinker.LinkedSprite;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -127,13 +127,13 @@ public class TreeTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item != null && item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Axe) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					hurt(level, xt, yt, tool.getDamage());
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
@@ -148,7 +148,7 @@ public class TreeTile extends Tile {
 
 	public void hurt(Level level, int x, int y, int dmg) {
 		if (random.nextInt(100) == 0)
-			level.dropItem(x * 16 + 8, y * 16 + 8, Items.get("Apple"));
+			level.dropItem(x * 16 + 8, y * 16 + 8, Items.getStackOf("Apple"));
 
 		int damage = level.getData(x, y) + dmg;
 		int treeHealth = 20;
@@ -159,8 +159,8 @@ public class TreeTile extends Tile {
 
 		level.add(new TextParticle("" + dmg, x * 16 + 8, y * 16 + 8, Color.RED));
 		if (damage >= treeHealth) {
-			level.dropItem(x * 16 + 8, y * 16 + 8, 1, 3, Items.get("Wood"));
-			level.dropItem(x * 16 + 8, y * 16 + 8, 0, 2, Items.get("Acorn"));
+			level.dropItem(x * 16 + 8, y * 16 + 8, 1, 3, Items.getStackOf("Wood"));
+			level.dropItem(x * 16 + 8, y * 16 + 8, 0, 2, Items.getStackOf("Acorn"));
 			level.setTile(x, y, Tiles.get("Grass"));
 			AchievementsDisplay.setAchievement("minicraft.achievement.woodcutter", true);
 		} else {

--- a/src/client/java/minicraft/level/tile/WallTile.java
+++ b/src/client/java/minicraft/level/tile/WallTile.java
@@ -13,7 +13,7 @@ import minicraft.entity.particle.TextParticle;
 import minicraft.gfx.Color;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.level.Level;
@@ -65,14 +65,14 @@ public class WallTile extends Tile {
 		}
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
 		if (Game.isMode("minicraft.settings.mode.creative"))
 			return false; // Go directly to hurt method
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+		if (item != null && item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == type.getRequiredTool()) {
 				if (level.depth != -3 || type != Material.Obsidian || AirWizard.beaten) {
-					if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+					if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 						int data = level.getData(xt, yt);
 						hurt(level, xt, yt, tool.getDamage());
 						AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
@@ -117,7 +117,7 @@ public class WallTile extends Tile {
 				}
 			}
 
-			level.dropItem((x << 4) + 8, (y << 4) + 8, 1, 3 - type.ordinal(), Items.get(itemName));
+			level.dropItem((x << 4) + 8, (y << 4) + 8, 1, 3 - type.ordinal(), Items.getStackOf(itemName));
 			level.setTile(x, y, Tiles.get(tilename));
 		} else {
 			level.setData(x, y, damage);

--- a/src/client/java/minicraft/level/tile/WoolTile.java
+++ b/src/client/java/minicraft/level/tile/WoolTile.java
@@ -7,7 +7,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
 import minicraft.item.DyeItem;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
@@ -29,15 +29,15 @@ public class WoolTile extends Tile {
 		super(color.toString().replace('_', ' ') + " Wool", sprites.get(color));
 	}
 
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shears) {
-				if (player.payStamina(3 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(3 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Hole"));
 					Sound.play("monsterhurt");
-					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.get(name));
+					level.dropItem((xt << 4) + 8, (yt << 4) + 8, Items.getStackOf(name));
 					AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.INSTANCE.trigger(
 						new AdvancementElement.AdvancementTrigger.ItemUsedOnTileTrigger.ItemUsedOnTileTriggerConditionHandler.ItemUsedOnTileTriggerConditions(
 							item, this, data, xt, yt, level.depth));

--- a/src/client/java/minicraft/level/tile/farming/CropTile.java
+++ b/src/client/java/minicraft/level/tile/farming/CropTile.java
@@ -7,9 +7,8 @@ import minicraft.entity.mob.Mob;
 import minicraft.entity.mob.Player;
 import minicraft.entity.particle.Particle;
 import minicraft.gfx.SpriteLinker;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
-import minicraft.item.StackableItem;
 import minicraft.level.Level;
 import minicraft.level.tile.Tile;
 import minicraft.level.tile.Tiles;
@@ -102,9 +101,9 @@ public class CropTile extends FarmTile {
 	private static final SpriteLinker.LinkedSprite particleSprite = new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Entity, "glint");
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof StackableItem && item.getName().equalsIgnoreCase("Fertilizer")) {
-			((StackableItem) item).count--;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item.isStackable() && item.getItem().getName().equalsIgnoreCase("Fertilizer")) {
+			item.decrement(1);
 			Random random = new Random();
 			for (int i = 0; i < 2; ++i) {
 				double x = (double) xt * 16 + 8 + (random.nextGaussian() * 0.5) * 8;
@@ -138,12 +137,12 @@ public class CropTile extends FarmTile {
 		int age = (data >> 3) & maxAge;
 
 		if (seed != null)
-			level.dropItem(x * 16 + 8, y * 16 + 8, 1, Items.get(seed));
+			level.dropItem(x * 16 + 8, y * 16 + 8, 1, Items.getStackOf(seed));
 
 		if (age == maxAge) {
-			level.dropItem(x * 16 + 8, y * 16 + 8, random.nextInt(3) + 2, Items.get(name));
+			level.dropItem(x * 16 + 8, y * 16 + 8, random.nextInt(3) + 2, Items.getStackOf(name));
 		} else if (seed == null) {
-			level.dropItem(x * 16 + 8, y * 16 + 8, 1, Items.get(name));
+			level.dropItem(x * 16 + 8, y * 16 + 8, 1, Items.getStackOf(name));
 		}
 
 		if (age == maxAge && entity instanceof Player) {

--- a/src/client/java/minicraft/level/tile/farming/FarmTile.java
+++ b/src/client/java/minicraft/level/tile/farming/FarmTile.java
@@ -6,7 +6,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteAnimation;
 import minicraft.gfx.SpriteLinker.SpriteType;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.ToolItem;
 import minicraft.item.ToolType;
 import minicraft.level.Level;
@@ -30,11 +30,11 @@ public class FarmTile extends Tile {
 	}
 
 	@Override
-	public boolean interact(Level level, int xt, int yt, Player player, Item item, Direction attackDir) {
-		if (item instanceof ToolItem) {
-			ToolItem tool = (ToolItem) item;
+	public boolean interact(Level level, int xt, int yt, Player player, ItemStack item, Direction attackDir) {
+		if (item != null && item.getItem() instanceof ToolItem) {
+			ToolItem tool = (ToolItem) item.getItem();
 			if (tool.type == ToolType.Shovel) {
-				if (player.payStamina(4 - tool.level) && tool.payDurability()) {
+				if (player.payStamina(4 - tool.level) && tool.payDurability(item)) {
 					int data = level.getData(xt, yt);
 					level.setTile(xt, yt, Tiles.get("Dirt"));
 					Sound.play("monsterhurt");

--- a/src/client/java/minicraft/saveload/LegacyLoad.java
+++ b/src/client/java/minicraft/saveload/LegacyLoad.java
@@ -29,10 +29,10 @@ import minicraft.entity.mob.Zombie;
 import minicraft.item.ArmorItem;
 import minicraft.item.Inventory;
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.PotionItem;
 import minicraft.item.PotionType;
-import minicraft.item.StackableItem;
 import minicraft.level.ChunkManager;
 import minicraft.level.Level;
 import minicraft.level.tile.Tiles;
@@ -259,7 +259,7 @@ public class LegacyLoad {
 			if (data.size() >= 14) {
 				if (worldVer == null) worldVer = new Version("1.9.1-pre1");
 				player.armorDamageBuffer = Integer.parseInt(data.get(13));
-				player.curArmor = (ArmorItem) Items.get(data.get(14));
+				player.curArmor = Items.getStackOf(data.get(14));
 			} else player.armor = 0;
 
 			Game.currentLevel = Integer.parseInt(data.get(8));
@@ -323,7 +323,7 @@ public class LegacyLoad {
 
 		if (playerac > 0 && inventory == Game.player.getInventory()) {
 			for (int i = 0; i < playerac; i++)
-				loadItem(inventory, Items.get("arrow"));
+				loadItem(inventory, Items.getStackOf("arrow"));
 			playerac = 0;
 		}
 	}
@@ -335,18 +335,18 @@ public class LegacyLoad {
 			if (oldSave) itemName = subOldName(itemName);
 
 			//System.out.println("Item to fetch: " + itemName + "; count=" + curData[1]);
-			Item newItem = Items.get(itemName);
+			ItemStack newItem = Items.getStackOf(itemName);
 			int count = Integer.parseInt(curData[1]);
 			for (int i = 0; i < count; i++)
 				loadItem(inventory, newItem);
 		} else {
 			if (oldSave) item = subOldName(item);
-			Item toAdd = Items.get(item);
+			ItemStack toAdd = Items.getStackOf(item);
 			loadItem(inventory, toAdd);
 		}
 	}
 
-	private void loadItem(Inventory inventory, Item item) {
+	private void loadItem(Inventory inventory, ItemStack item) {
 		if (inventory.add(item) != null) {
 			deathChest.getInventory().add(item.copy());
 		}

--- a/src/client/java/minicraft/saveload/Load.java
+++ b/src/client/java/minicraft/saveload/Load.java
@@ -46,11 +46,11 @@ import minicraft.item.ArmorItem;
 import minicraft.item.DyeItem;
 import minicraft.item.Inventory;
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.PotionItem;
 import minicraft.item.PotionType;
 import minicraft.item.Recipe;
-import minicraft.item.StackableItem;
 import minicraft.level.ChunkManager;
 import minicraft.level.Level;
 import minicraft.level.tile.Tiles;
@@ -1128,11 +1128,11 @@ public class Load {
 		if (worldVer.compareTo(new Version("2.0.5-dev5")) >= 0 || player.armor > 0 || worldVer.compareTo(new Version("2.0.5-dev4")) == 0 && data.size() > 5) {
 			if (worldVer.compareTo(new Version("2.0.4-dev7")) < 0) {
 				// Reverse order b/c we are taking from the end
-				player.curArmor = (ArmorItem) Items.get(data.remove(data.size() - 1));
+				player.curArmor = Items.getStackOf(data.remove(data.size() - 1));
 				player.armorDamageBuffer = Integer.parseInt(data.remove(data.size() - 1));
 			} else {
 				player.armorDamageBuffer = Integer.parseInt(data.remove(0));
-				player.curArmor = (ArmorItem) Items.get(data.remove(0), true);
+				player.curArmor = Items.getStackOf(data.remove(0), true);
 			}
 		}
 		player.setScore(Integer.parseInt(data.remove(0)));
@@ -1140,7 +1140,7 @@ public class Load {
 		if (worldVer.compareTo(new Version("2.0.4-dev7")) < 0) {
 			int arrowCount = Integer.parseInt(data.remove(0));
 			if (worldVer.compareTo(new Version("2.0.1-dev1")) < 0)
-				player.getInventory().add(Items.get("arrow"), arrowCount).forEach(deathChest.getInventory()::add);
+				player.getInventory().add(Items.getStackOf("arrow"), arrowCount).forEach(deathChest.getInventory()::add);
 		}
 
 		Game.currentLevel = Integer.parseInt(data.remove(0));
@@ -1296,23 +1296,23 @@ public class Load {
 				String[] curData = item.split(";");
 				String itemName = curData[0];
 
-				Item newItem = Items.get(itemName);
+				ItemStack newItem = Items.getStackOf(itemName);
 
 				int count = Integer.parseInt(curData[1]);
 
-				if (newItem instanceof StackableItem) {
-					((StackableItem) newItem).count = count;
+				if (newItem.isStackable()) {
+					newItem.setCount(count);
 					loadItem(inventory, newItem);
 				} else {
 					for (int i = 0; i < count; i++) loadItem(inventory, newItem);
 				}
 			} else {
-				loadItem(inventory, Items.get(item));
+				loadItem(inventory, Items.getStackOf(item));
 			}
 		}
 	}
 
-	private void loadItem(Inventory inventory, Item item) {
+	private void loadItem(Inventory inventory, ItemStack item) {
 		if (inventory.add(item) != null) {
 			deathChest.getInventory().add(item.copy());
 		}
@@ -1463,7 +1463,7 @@ public class Load {
 				if (itemData.contains("Power Glove")) continue;
 				if (itemData.contains("Totem of Wind")) continue;
 
-				Item item = Items.get(itemData);
+				ItemStack item = Items.getStackOf(itemData);
 				chest.getInventory().add(item);
 			}
 
@@ -1500,7 +1500,7 @@ public class Load {
 				}
 			}
 			if (newEntity instanceof ItemEntity) {
-				Item item = Items.get(info.get(2));
+				ItemStack item = Items.getStackOf(info.get(2));
 				double zz = Double.parseDouble(info.get(3));
 				int lifetime = Integer.parseInt(info.get(4));
 				int timeleft = Integer.parseInt(info.get(5));
@@ -1584,7 +1584,7 @@ public class Load {
 			case "Arrow":
 				return new Arrow(new Skeleton(0), 0, 0, Direction.NONE, 0);
 			case "ItemEntity":
-				return new ItemEntity(Items.get("unknown"), 0, 0);
+				return new ItemEntity(Items.getStackOf("unknown"), 0, 0);
 			case "FireParticle":
 				return new FireParticle(0, 0);
 			case "SmashParticle":

--- a/src/client/java/minicraft/saveload/Save.java
+++ b/src/client/java/minicraft/saveload/Save.java
@@ -31,6 +31,7 @@ import minicraft.entity.vehicle.Boat;
 import minicraft.gfx.Point;
 import minicraft.item.Inventory;
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.PotionType;
 import minicraft.item.Recipe;
 import minicraft.level.ChunkManager;
@@ -375,7 +376,7 @@ public class Save {
 		for (Recipe recipe : CraftingDisplay.getUnlockedRecipes()) {
 			JSONArray costs = new JSONArray();
 			recipe.getCosts().forEach((c, i) -> costs.put(c + "_" + i));
-			unlockedRecipes.put(recipe.getProduct().getName() + "_" + recipe.getAmount(), costs);
+			unlockedRecipes.put(recipe.getProduct().getItem().getName() + "_" + recipe.getAmount(), costs);
 		}
 		data.add(unlockedRecipes.toString());
 	}
@@ -435,7 +436,7 @@ public class Save {
 			Chest chest = (Chest) e;
 
 			for (int ii = 0; ii < chest.getInventory().invSize(); ii++) {
-				Item item = chest.getInventory().get(ii);
+				ItemStack item = chest.getInventory().get(ii);
 				extradata.append(":").append(item.getData());
 			}
 

--- a/src/client/java/minicraft/screen/ContainerDisplay.java
+++ b/src/client/java/minicraft/screen/ContainerDisplay.java
@@ -16,7 +16,7 @@ import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker;
 import minicraft.item.Inventory;
 import minicraft.item.Item;
-import minicraft.item.StackableItem;
+import minicraft.item.ItemStack;
 
 public class ContainerDisplay extends Display {
 
@@ -317,24 +317,24 @@ public class ContainerDisplay extends Display {
 				int toSel = menus[otherIdx].getSelection();
 				int fromSel = curMenu.getSelection();
 
-				Item fromItem = from.get(fromSel);
+				ItemStack fromItem = from.get(fromSel);
 
-				boolean transferAll = input.getMappedKey("shift").isDown() || !(fromItem instanceof StackableItem) || ((StackableItem) fromItem).count == 1;
+				boolean transferAll = input.getMappedKey("shift").isDown() || fromItem.getCount() == 1;
 
-				Item toItem = fromItem.copy();
+				ItemStack toItem = fromItem.copy();
 
-				if (fromItem instanceof StackableItem) {
+				if (fromItem.isStackable()) {
 					int move = 1;
 					if (!transferAll) {
-						((StackableItem) toItem).count = 1;
+						toItem.setCount(1);
 					} else {
-						move = ((StackableItem) toItem).count;
+						move = toItem.getCount();
 					}
 
 					if (to.add(toItem) != null) {
-						((StackableItem)fromItem).count -= move - ((StackableItem) toItem).count;
+						fromItem.decrement(move - toItem.getCount());
 					} else if (!transferAll) {
-						((StackableItem) fromItem).count--;
+						fromItem.decrement(1);
 					} else {
 						from.remove(fromSel);
 					}

--- a/src/client/java/minicraft/screen/CraftingDisplay.java
+++ b/src/client/java/minicraft/screen/CraftingDisplay.java
@@ -8,7 +8,7 @@ import minicraft.entity.mob.Player;
 import minicraft.gfx.MinicraftImage;
 import minicraft.gfx.Point;
 import minicraft.gfx.Screen;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
 import minicraft.item.Recipe;
 import minicraft.screen.entry.ItemListing;
@@ -98,7 +98,7 @@ public class CraftingDisplay extends Display {
 
 		Map<String, Integer> costMap = recipes[recipeMenu.getSelection()].getCosts();
 		for (String itemName : costMap.keySet()) {
-			Item cost = Items.get(itemName);
+			ItemStack cost = Items.getStackOf(itemName);
 			costList.add(new ItemListing(cost, player.getInventory().count(cost) + "/" + costMap.get(itemName)));
 		}
 
@@ -163,30 +163,30 @@ public class CraftingDisplay extends Display {
 				if (recipes.length == 0) return;
 				Recipe selectedRecipe = recipes[recipeMenu.getSelection()];
 				if (selectedRecipe.getCanCraft()) {
-					if (selectedRecipe.getProduct().equals(Items.get("Workbench"))) {
+					if (selectedRecipe.getProduct().equals(Items.getStackOf("Workbench"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.benchmarking", true);
-					} else if (selectedRecipe.getProduct().equals(Items.get("Plank"))) {
+					} else if (selectedRecipe.getProduct().equals(Items.getStackOf("Plank"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.planks", true);
-					} else if (selectedRecipe.getProduct().equals(Items.get("Wood Door"))) {
+					} else if (selectedRecipe.getProduct().equals(Items.getStackOf("Wood Door"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.doors", true);
-					} else if (selectedRecipe.getProduct().equals(Items.get("Rock Sword")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Pickaxe")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Axe")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Shovel")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Hoe")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Bow")) ||
-						selectedRecipe.getProduct().equals(Items.get("Rock Claymore"))) {
+					} else if (selectedRecipe.getProduct().equals(Items.getStackOf("Rock Sword")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Pickaxe")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Axe")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Shovel")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Hoe")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Bow")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("Rock Claymore"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.upgrade", true);
-					} else if (selectedRecipe.getProduct().equals(Items.get("blue clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("green clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("yellow clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("black clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("orange clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("purple clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("cyan clothes")) ||
-						selectedRecipe.getProduct().equals(Items.get("reg clothes"))) {
+					} else if (selectedRecipe.getProduct().equals(Items.getStackOf("blue clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("green clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("yellow clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("black clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("orange clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("purple clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("cyan clothes")) ||
+						selectedRecipe.getProduct().equals(Items.getStackOf("reg clothes"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.clothes", true);
-					} else if (selectedRecipe.getProduct().equals(Items.get("Boat"))) {
+					} else if (selectedRecipe.getProduct().equals(Items.getStackOf("Boat"))) {
 						AchievementsDisplay.setAchievement("minicraft.achievement.boat", true);
 					}
 

--- a/src/client/java/minicraft/screen/EndGameDisplay.java
+++ b/src/client/java/minicraft/screen/EndGameDisplay.java
@@ -64,7 +64,7 @@ public class EndGameDisplay extends Display {
 	}
 
 	private void addBonus(String item) {
-		int count = Game.player.getInventory().count(Items.get(item));
+		int count = Game.player.getInventory().count(Items.getStackOf(item));
 		int score = count * (random.nextInt(2) + 1) * 10;
 		finalScore += score;
 	}

--- a/src/client/java/minicraft/screen/InventoryMenu.java
+++ b/src/client/java/minicraft/screen/InventoryMenu.java
@@ -4,8 +4,7 @@ import minicraft.core.Action;
 import minicraft.core.io.InputHandler;
 import minicraft.entity.Entity;
 import minicraft.item.Inventory;
-import minicraft.item.Item;
-import minicraft.item.StackableItem;
+import minicraft.item.ItemStack;
 import minicraft.screen.entry.ItemEntry;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,17 +49,17 @@ class InventoryMenu extends ItemListMenu {
 		if (getNumOptions() > 0 && (dropOne || input.inputPressed("drop-stack"))) {
 			ItemEntry entry = ((ItemEntry) getCurEntry());
 			if (entry == null) return;
-			Item invItem = entry.getItem();
-			Item drop = invItem.copy();
+			ItemStack invItem = entry.getItem();
+			ItemStack drop = invItem.copy();
 
 			if (!creativeInv) {
-				if (!dropOne || !(drop instanceof StackableItem) || ((StackableItem) drop).count <= 1) {
+				if (!dropOne || !(drop.isStackable()) || drop.getCount() <= 1) {
 					// drop the whole item.
 					removeSelectedEntry();
 				} else {
 					// just drop one from the stack
-					((StackableItem) drop).count = 1;
-					((StackableItem) invItem).count--;
+					drop.setCount(1);
+					invItem.decrement(1);
 				}
 
 				if (onStackUpdateListener != null) {

--- a/src/client/java/minicraft/screen/PlayerInvDisplay.java
+++ b/src/client/java/minicraft/screen/PlayerInvDisplay.java
@@ -14,9 +14,8 @@ import minicraft.gfx.Rectangle;
 import minicraft.gfx.Screen;
 import minicraft.gfx.SpriteLinker;
 import minicraft.item.Inventory;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 import minicraft.item.Items;
-import minicraft.item.StackableItem;
 import minicraft.screen.entry.StringEntry;
 import minicraft.util.Logging;
 
@@ -136,19 +135,19 @@ public class PlayerInvDisplay extends Display {
 					from = player.getInventory();
 
 					int fromSel = curMenu.getSelection();
-					Item fromItem = from.get(fromSel);
+					ItemStack fromItem = from.get(fromSel);
 
 					boolean deleteAll;
 					if (input.getMappedKey("SHIFT-D").isClicked() || input.buttonPressed(ControllerButton.Y)) {
 						deleteAll = true;
 					} else if (input.getMappedKey("D").isClicked() || input.buttonPressed(ControllerButton.X)) {
-						deleteAll = !(fromItem instanceof StackableItem) || ((StackableItem) fromItem).count == 1;
+						deleteAll = fromItem.getCount() == 1;
 					} else return;
 
 					if (deleteAll) {
 						from.remove(fromSel);
 					} else {
-						((StackableItem) fromItem).count--; // this is known to be valid.
+						fromItem.decrement(1); // this is known to be valid.
 					}
 
 					update();
@@ -160,18 +159,18 @@ public class PlayerInvDisplay extends Display {
 					int toSel = menus[otherIdx].getSelection();
 					int fromSel = curMenu.getSelection();
 
-					Item fromItem = from.get(fromSel);
+					ItemStack fromItem = from.get(fromSel);
 
 					boolean transferAll;
 					if (input.getMappedKey("SHIFT-SELECT").isClicked()) {
 						transferAll = true;
 					} else if (input.inputPressed("SELECT")) { // If stack limit is available, this can transfer whole stack
-						transferAll = !(fromItem instanceof StackableItem);
+						transferAll = !(fromItem.isStackable());
 					} else return;
 
-					Item toItem = fromItem.copy();
-					if (toItem instanceof StackableItem && transferAll)
-						((StackableItem) toItem).count = ((StackableItem) toItem).maxCount;
+					ItemStack toItem = fromItem.copy();
+					if (toItem.isStackable() && transferAll)
+						toItem.setCount(toItem.getMaxCount());
 
 					if (to.add(toItem) != null)
 						Logging.PLAYER.trace("Item {} cannot be added to the player inventory because max slot reached.", toItem);

--- a/src/client/java/minicraft/screen/entry/ItemEntry.java
+++ b/src/client/java/minicraft/screen/entry/ItemEntry.java
@@ -2,26 +2,26 @@ package minicraft.screen.entry;
 
 import minicraft.core.io.InputHandler;
 import minicraft.gfx.Screen;
-import minicraft.item.Item;
+import minicraft.item.ItemStack;
 
 import java.util.List;
 
 public class ItemEntry extends ListEntry {
 
-	public static ItemEntry[] useItems(List<Item> items) {
+	public static ItemEntry[] useItems(List<ItemStack> items) {
 		ItemEntry[] entries = new ItemEntry[items.size()];
 		for (int i = 0; i < items.size(); i++)
 			entries[i] = new ItemEntry(items.get(i));
 		return entries;
 	}
 
-	private Item item;
+	private ItemStack item;
 
-	public ItemEntry(Item i) {
+	public ItemEntry(ItemStack i) {
 		this.item = i;
 	}
 
-	public Item getItem() {
+	public ItemStack getItem() {
 		return item;
 	}
 
@@ -32,12 +32,12 @@ public class ItemEntry extends ListEntry {
 	@Override
 	public void render(Screen screen, int x, int y, boolean isSelected) {
 		super.render(screen, x, y, true);
-		screen.render(x, y, item.sprite);
+		screen.render(x, y, item.getSprite());
 	}
 
 	// If you add to the length of the string, and therefore the width of the entry, then it will actually move the entry RIGHT in the inventory, instead of the intended left, because it is auto-positioned to the left side.
 	@Override
 	public String toString() {
-		return item.getDisplayName();
+		return item.getItem().getDisplayName(item);
 	}
 }

--- a/src/client/java/minicraft/screen/entry/ItemListing.java
+++ b/src/client/java/minicraft/screen/entry/ItemListing.java
@@ -1,12 +1,13 @@
 package minicraft.screen.entry;
 
 import minicraft.item.Item;
+import minicraft.item.ItemStack;
 
 public class ItemListing extends ItemEntry {
 
 	private String info;
 
-	public ItemListing(Item i, String text) {
+	public ItemListing(ItemStack i, String text) {
 		super(i);
 		setSelectable(false);
 		this.info = text;

--- a/src/client/java/minicraft/screen/entry/RecipeEntry.java
+++ b/src/client/java/minicraft/screen/entry/RecipeEntry.java
@@ -31,7 +31,7 @@ public class RecipeEntry extends ItemEntry {
 	public void render(Screen screen, int x, int y, boolean isSelected) {
 		if (isVisible()) {
 			Font.draw(toString(), screen, x, y, recipe.getCanCraft() ? COL_SLCT : COL_UNSLCT);
-			screen.render(x, y, getItem().sprite);
+			screen.render(x, y, getItem().getSprite());
 		}
 	}
 


### PR DESCRIPTION
Use an ItemStack to represent an Item instance, and make Item simply be a "definition"/type (as much as possible righ now). It could be named ItemInstance but visually ItemStack looks nicer.

Even though the ItemStack has a count and maxCount was moved to the Item class, I didn't remove the StackableItem because I didn't know what to rename it to. 

Eventually I would prefer to get rid of the whole NAME + _ + AMOUNT string usage and just use the ItemStack. But I don't know if it should be done in this pull request. 