### PR TITLE
Fix `EntitySummonItem` summoning in blocking tiles & not decrementing on usages

### DIFF
--- a/src/client/java/minicraft/entity/vehicle/Boat.java
+++ b/src/client/java/minicraft/entity/vehicle/Boat.java
@@ -19,6 +19,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class Boat extends Entity implements PlayerRideable {
+	public static final int RADIUS_X = 6;
+	public static final int RADIUS_Y = 6;
+
 	private static final SpriteLinker.LinkedSprite[][] boatSprites = new SpriteLinker.LinkedSprite[][] {
 		Mob.compileSpriteList(0, 0, 3, 3, 0, 4, "boat"), //
 		Mob.compileSpriteList(0, 3, 3, 3, 0, 4, "boat")
@@ -34,7 +37,7 @@ public class Boat extends Entity implements PlayerRideable {
 	private int unitMoveCounter = 0;
 
 	public Boat(@NotNull Direction dir) {
-		super(6, 6);
+		super(RADIUS_X, RADIUS_Y);
 		this.dir = dir;
 	}
 

--- a/src/client/java/minicraft/item/EntitySummonItem.java
+++ b/src/client/java/minicraft/item/EntitySummonItem.java
@@ -16,20 +16,44 @@ import java.util.function.Supplier;
 public class EntitySummonItem extends StackableItem {
 	protected static ArrayList<Item> getAllInstances() {
 		ArrayList<Item> items = new ArrayList<>();
-		items.add(new EntitySummonItem("Boat", new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Item, "boat"), Boat::new));
+		items.add(new EntitySummonItem("Boat", new SpriteLinker.LinkedSprite(SpriteLinker.SpriteType.Item, "boat"), Boat::new, Boat.RADIUS_X, Boat.RADIUS_Y, new Boat(Direction.NONE)));
 		return items;
 	}
 
 	private final @NotNull Function<Direction, Entity> entitySupplier;
+	private final @NotNull Entity testDummy; // Only used for tile passing test
+	private final int xr, yr;
 
-	protected EntitySummonItem(String name, SpriteLinker.LinkedSprite sprite, @NotNull Function<Direction, Entity> entitySupplier) {
+	protected EntitySummonItem(String name, SpriteLinker.LinkedSprite sprite, @NotNull Function<Direction, Entity> entitySupplier, int xr, int yr, @NotNull Entity testDummy) {
 		super(name, sprite);
 		this.entitySupplier = entitySupplier;
+		this.xr = xr;
+		this.yr = yr;
+		this.testDummy = testDummy;
 	}
 
 	@Override
 	public boolean interactOn(Tile tile, Level level, int xt, int yt, Player player, Direction attackDir) {
-		level.add(entitySupplier.apply(attackDir), player.x + 12 * attackDir.getX(), player.y + 12 * attackDir.getY());
+		if (isAreaClear(level, xt, yt)) {
+			level.add(entitySupplier.apply(attackDir), player.x + 12 * attackDir.getX(), player.y + 12 * attackDir.getY());
+			return super.interactOn(true);
+		}
+
+		return super.interactOn(false);
+	}
+
+	private boolean isAreaClear(Level level, int xt, int yt) {
+		// X/Y-Starting/Ending points
+		final int xs = ((xt << 4) - xr) >> 4;
+		final int xe = ((xt << 4) + xr) >> 4;
+		final int ys = ((yt << 4) - yr) >> 4;
+		final int ye = ((yt << 4) + yr) >> 4;
+		for (int x = xs; x <= xe; x++) {
+			for (int y = ys; y <= ye; y++) {
+				if (!level.getTile(x, y).mayPass(level, x, y, testDummy)) return false;
+			}
+		}
+
 		return true;
 	}
 
@@ -40,6 +64,6 @@ public class EntitySummonItem extends StackableItem {
 
 	@Override
 	public @NotNull StackableItem copy() {
-		return new EntitySummonItem(getName(), sprite, entitySupplier);
+		return new EntitySummonItem(getName(), sprite, entitySupplier, xr, yr, testDummy);
 	}
 }


### PR DESCRIPTION
This fixes #744.

Basically, `EntitySummonItem` was not correcting implementing a subclass of `StackableItem` where its subclasses should always invoke `StackableItem#interactOn(boolean)` (at least when `true` for it to work properly) in their overrides of the `interactOn` method. Also, I discovered that it does not check whether the placing target is *solid* (blocking) to the entity, so that players may pass through a solid tile by placing a boat on it.

The code content is not perfect as a solution due to the codebase (and class) structures, but should be sufficient to solve those bugs. What I meant by this is that it should be more polymorphic and whatever, so that duplicated attributes may not have to be repeated (using configuring/attributive/etc. objects) and dummy objects may not be used.